### PR TITLE
docs: remove mentions of coral, it's not implemented

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const RandomWalk = require('./random-walk')
 const assert = require('assert')
 
 /**
- * A DHT implementation modeled after Kademlia with Coral and S/Kademlia modifications.
+ * A DHT implementation modeled after Kademlia with S/Kademlia modifications.
  *
  * Original implementation in go: https://github.com/libp2p/go-libp2p-kad-dht.
  */
@@ -400,9 +400,7 @@ class KadDHT {
   // ----------- Content Routing
 
   /**
-   * Announce to the network that a node can provide the given key.
-   * This is what Coral and MainlineDHT do to store large values
-   * in a DHT.
+   * Announce to the network that we can provide given key's value.
    *
    * @param {CID} key
    * @param {function(Error)} callback

--- a/src/message/dht.proto.js
+++ b/src/message/dht.proto.js
@@ -53,6 +53,7 @@ message Message {
   optional MessageType type = 1;
 
   // defines what coral cluster level this query/response belongs to.
+  // in case we want to implement coral's cluster rings in the future.
   optional int32 clusterLevelRaw = 10;
 
   // Used to specify the key associated with this message.


### PR DESCRIPTION
Initially our DHT was meant to get some of Coral's features (cluster rings -- that's why there's `clusterRawLevel`), but we never got to it. Let's strip the mentions of it.