### PR TITLE
fix: make findProviders treat timeout the same as findPeer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -433,6 +433,15 @@ class KadDHT {
    * @returns {void}
    */
   findProviders (key, timeout, callback) {
+    if (typeof timeout === 'function') {
+      callback = timeout
+      timeout = null
+    }
+
+    if (timeout == null) {
+      timeout = c.minute
+    }
+
     this._log('findProviders %s', key.toBaseEncodedString())
     this._findNProviders(key, timeout, c.K, callback)
   }


### PR DESCRIPTION
findPeer currently sets a default timeout if one is not given, this updates findProviders to do the same. If a timeout is not given, the call will immediately timeout and return an ETIMEDOUT error.

The default timeout is set to 1 minute, to match findPeer.