### PR TITLE
fix: dht get options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -179,21 +179,28 @@ class KadDHT {
    * Times out after 1 minute.
    *
    * @param {Buffer} key
-   * @param {number} [maxTimeout=60000] - optional timeout
+   * @param {Object} options - get options
+   * @param {number} options.maxTimeout - optional timeout (default: 60000)
    * @param {function(Error, Buffer)} callback
    * @returns {void}
    */
-  get (key, maxTimeout, callback) {
-    if (typeof maxTimeout === 'function') {
-      callback = maxTimeout
-      maxTimeout = null
+  get (key, options, callback) {
+    if (typeof options === 'function') {
+      callback = options
+      options = {}
+    } else if (typeof options === 'number') { // This will be deprecated in a next release
+      options = {
+        maxTimeout: options
+      }
+    } else {
+      options = options || {}
     }
 
-    if (maxTimeout == null) {
-      maxTimeout = c.minute
+    if (!options.maxTimeout) {
+      options.maxTimeout = c.minute
     }
 
-    this._get(key, maxTimeout, callback)
+    this._get(key, options, callback)
   }
 
   /**
@@ -201,17 +208,25 @@ class KadDHT {
    *
    * @param {Buffer} key
    * @param {number} nvals
-   * @param {number} [maxTimeout=60000]
+   * @param {Object} options - get options
+   * @param {number} options.maxTimeout - optional timeout (default: 60000)
    * @param {function(Error, Array<{from: PeerId, val: Buffer}>)} callback
    * @returns {void}
    */
-  getMany (key, nvals, maxTimeout, callback) {
-    if (typeof maxTimeout === 'function') {
-      callback = maxTimeout
-      maxTimeout = null
+  getMany (key, nvals, options, callback) {
+    if (typeof options === 'function') {
+      callback = options
+      options = {}
+    } else if (typeof options === 'number') { // This will be deprecated in a next release
+      options = {
+        maxTimeout: options
+      }
+    } else {
+      options = options || {}
     }
-    if (maxTimeout == null) {
-      maxTimeout = c.minute
+
+    if (!options.maxTimeout) {
+      options.maxTimeout = c.minute
     }
 
     this._log('getMany %b (%s)', key, nvals)
@@ -274,7 +289,7 @@ class KadDHT {
           })
 
           // run our query
-          timeout((cb) => query.run(rtp, cb), maxTimeout)(cb)
+          timeout((cb) => query.run(rtp, cb), options.maxTimeout)(cb)
         }
       ], (err) => {
         if (err && vals.length === 0) {

--- a/src/private.js
+++ b/src/private.js
@@ -283,16 +283,17 @@ module.exports = (dht) => ({
    * Get the value to the given key.
    *
    * @param {Buffer} key
-   * @param {number} maxTimeout
-   * @param {function(Error, Buffer)} callback
+   * @param {Object} options - get options
+   * @param {number} options.maxTimeout - optional timeout (default: 60000)
+   * @param {function(Error, Record)} callback
    * @returns {void}
    *
    * @private
    */
-  _get (key, maxTimeout, callback) {
+  _get (key, options, callback) {
     dht._log('_get %b', key)
     waterfall([
-      (cb) => dht.getMany(key, 16, maxTimeout, cb),
+      (cb) => dht.getMany(key, 16, options.maxTimeout, cb),
       (vals, cb) => {
         const recs = vals.map((v) => v.val)
         const i = libp2pRecord.selection.bestRecord(dht.selectors, key, recs)

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -147,7 +147,7 @@ describe('KadDHT', () => {
       waterfall([
         (cb) => connect(dhtA, dhtB, cb),
         (cb) => dhtA.put(Buffer.from('/v/hello'), Buffer.from('world'), cb),
-        (cb) => dhtB.get(Buffer.from('/v/hello'), 1000, cb),
+        (cb) => dhtB.get(Buffer.from('/v/hello'), { maxTimeout: 1000 }, cb),
         (res, cb) => {
           expect(res).to.eql(Buffer.from('world'))
           cb()
@@ -244,7 +244,7 @@ describe('KadDHT', () => {
           Buffer.from('world'),
           cb
         ),
-        (cb) => dhts[0].get(Buffer.from('/v/hello'), 1000, cb),
+        (cb) => dhts[0].get(Buffer.from('/v/hello'), { maxTimeout: 1000 }, cb),
         (res, cb) => {
           expect(res).to.eql(Buffer.from('world'))
           cb()


### PR DESCRIPTION
Changed `dht.get` and `dht.getMany` `maxTimeout` parameter to an `options` parameter with the `maxTimeout` property as discussed [here](https://github.com/libp2p/js-libp2p/pull/248#pullrequestreview-156962993).