### PR TITLE
feat: start random walk and allow configuration for disabling

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "datastore-level": "~0.8.0",
     "dirty-chai": "^2.0.1",
     "interface-connection": "~0.3.2",
-    "libp2p-mplex": "~0.8.0",
+    "libp2p-mplex": "~0.8.1",
     "libp2p-switch": "~0.40.5",
     "libp2p-tcp": "~0.12.0",
     "lodash": "^4.17.10",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "lodash": "^4.17.10",
     "lodash.random": "^3.2.0",
     "lodash.range": "^3.2.0",
-    "peer-book": "~0.8.0"
+    "peer-book": "~0.8.0",
+    "sinon": "^6.3.4"
   },
   "contributors": [
     "Blake Byrnes <blakebyrnes@gmail.com>",

--- a/src/index.js
+++ b/src/index.js
@@ -115,14 +115,7 @@ class KadDHT {
    */
   start (callback) {
     this._running = true
-    this.network.start((err) => {
-      if (err) {
-        return callback(err)
-      }
-      this.randomWalk.start()
-
-      callback()
-    })
+    this.network.start(callback)
   }
 
   /**
@@ -134,7 +127,7 @@ class KadDHT {
    */
   stop (callback) {
     this._running = false
-    this.randomWalk.stop(() => {
+    this.randomWalk.stop(() => { // guarantee that random walk is stopped if it was started
       this.providers.stop()
       this.network.stop(callback)
     })

--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,11 @@ class KadDHT {
   /**
    * Create a new KadDHT.
    *
-   * @param {Switch} sw
-   * @param {object} options // {kBucketSize=20, datastore=MemoryDatastore}
+   * @param {Switch} sw libp2p-switch instance
+   * @param {object} options DHT options
+   * @param {number} options.kBucketSize k-bucket size (default 20)
+   * @param {Datastore} options.datastore datastore (default MemoryDatastore)
+   * @param {boolean} options.enabledDiscovery enable dht discovery (default true)
    */
   constructor (sw, options) {
     assert(sw, 'libp2p-kad-dht requires a instance of Switch')
@@ -96,6 +99,11 @@ class KadDHT {
      * @type {RandomWalk}
      */
     this.randomWalk = new RandomWalk(this)
+
+    /**
+     * Random walk state, default true
+     */
+    this.randomWalkEnabled = !options.hasOwnProperty('enabledDiscovery') ? true : Boolean(options.enabledDiscovery)
   }
 
   /**
@@ -115,7 +123,15 @@ class KadDHT {
    */
   start (callback) {
     this._running = true
-    this.network.start(callback)
+    this.network.start((err) => {
+      if (err) {
+        return callback(err)
+      }
+
+      // Start random walk if enabled
+      this.randomWalkEnabled && this.randomWalk.start()
+      callback()
+    })
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,14 @@ class KadDHT {
    */
   start (callback) {
     this._running = true
-    this.network.start(callback)
+    this.network.start((err) => {
+      if (err) {
+        return callback(err)
+      }
+      this.randomWalk.start()
+
+      callback()
+    })
   }
 
   /**
@@ -127,9 +134,10 @@ class KadDHT {
    */
   stop (callback) {
     this._running = false
-    this.randomWalk.stop()
-    this.providers.stop()
-    this.network.stop(callback)
+    this.randomWalk.stop(() => {
+      this.providers.stop()
+      this.network.stop(callback)
+    })
   }
 
   /**

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -4,6 +4,7 @@
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
+const sinon = require('sinon')
 const series = require('async/series')
 const times = require('async/times')
 const parallel = require('async/parallel')
@@ -135,6 +136,68 @@ describe('KadDHT', () => {
     expect(dht).to.have.property('routingTable')
   })
 
+  it('should be able to start and stop', function (done) {
+    const sw = new Switch(peerInfos[0], new PeerBook())
+    sw.transport.add('tcp', new TCP())
+    sw.connection.addStreamMuxer(Mplex)
+    sw.connection.reuse()
+    const dht = new KadDHT(sw)
+
+    sinon.spy(dht.network, 'start')
+    sinon.spy(dht.randomWalk, 'start')
+
+    sinon.spy(dht.network, 'stop')
+    sinon.spy(dht.randomWalk, 'stop')
+
+    series([
+      (cb) => dht.start(cb),
+      (cb) => {
+        expect(dht.network.start.calledOnce).to.equal(true)
+        expect(dht.randomWalk.start.calledOnce).to.equal(true)
+
+        cb()
+      },
+      (cb) => dht.stop(cb)
+    ], (err) => {
+      expect(err).to.not.exist()
+      expect(dht.network.stop.calledOnce).to.equal(true)
+      expect(dht.randomWalk.stop.calledOnce).to.equal(true)
+
+      done()
+    })
+  })
+
+  it('should be able to start with random-walk disabled', function (done) {
+    const sw = new Switch(peerInfos[0], new PeerBook())
+    sw.transport.add('tcp', new TCP())
+    sw.connection.addStreamMuxer(Mplex)
+    sw.connection.reuse()
+    const dht = new KadDHT(sw, { enabledDiscovery: false })
+
+    sinon.spy(dht.network, 'start')
+    sinon.spy(dht.randomWalk, 'start')
+
+    sinon.spy(dht.network, 'stop')
+    sinon.spy(dht.randomWalk, 'stop')
+
+    series([
+      (cb) => dht.start(cb),
+      (cb) => {
+        expect(dht.network.start.calledOnce).to.equal(true)
+        expect(dht.randomWalk.start.calledOnce).to.equal(false)
+
+        cb()
+      },
+      (cb) => dht.stop(cb)
+    ], (err) => {
+      expect(err).to.not.exist()
+      expect(dht.network.stop.calledOnce).to.equal(true)
+      expect(dht.randomWalk.stop.calledOnce).to.equal(true) // Should be always disabled, as it can be started using the instance
+
+      done()
+    })
+  })
+
   it('put - get', function (done) {
     this.timeout(10 * 1000)
     const tdht = new TestDHT()
@@ -206,7 +269,8 @@ describe('KadDHT', () => {
     const nDHTs = 20
     const tdht = new TestDHT()
 
-    tdht.spawn(nDHTs, (err, dhts) => {
+    // random walk disabled for a manual usage
+    tdht.spawn(nDHTs, { enabledDiscovery: false }, (err, dhts) => {
       expect(err).to.not.exist()
 
       series([

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -69,7 +69,7 @@ function connect (a, b, callback) {
 
 function bootstrap (dhts) {
   dhts.forEach((dht) => {
-    dht.randomWalk._walk(3, 10000)
+    dht.randomWalk._walk(3, 10000, () => {}) // don't need to know when it finishes
   })
 }
 
@@ -217,7 +217,6 @@ describe('KadDHT', () => {
         (cb) => {
           bootstrap(dhts)
           waitForWellFormedTables(dhts, 7, 0, 20 * 1000, cb)
-          cb()
         }
       ], (err) => {
         expect(err).to.not.exist()

--- a/test/utils/test-dht.js
+++ b/test/utils/test-dht.js
@@ -18,14 +18,24 @@ class TestDHT {
     this.nodes = []
   }
 
-  spawn (n, callback) {
-    times(n, (i, cb) => this._spawnOne(cb), (err, dhts) => {
+  spawn (n, options, callback) {
+    if (typeof options === 'function') {
+      callback = options
+      options = {}
+    }
+
+    times(n, (i, cb) => this._spawnOne(options, cb), (err, dhts) => {
       if (err) { return callback(err) }
       callback(null, dhts)
     })
   }
 
-  _spawnOne (callback) {
+  _spawnOne (options, callback) {
+    if (typeof options === 'function') {
+      callback = options
+      options = {}
+    }
+
     createPeerInfo(1, (err, peers) => {
       if (err) { return callback(err) }
 
@@ -37,7 +47,7 @@ class TestDHT {
       sw.connection.addStreamMuxer(Mplex)
       sw.connection.reuse()
 
-      const dht = new KadDHT(sw)
+      const dht = new KadDHT(sw, options)
 
       dht.validators.v = {
         func (key, publicKey, callback) {


### PR DESCRIPTION
In the context of the integration of the DHT to `js-ipfs` [js-ipfs#856](https://github.com/ipfs/js-ipfs/pull/856).

I changed the implementation of `randomWalk`. It was using a `setInterval`, which was causing this function to run the `_walk` function after five minutes. On the contrary, `go-libp2p-kad-dht` runs immediately after the node starts and then, each 5 minutes, as we can see in [go-libp2p-kad-dht/dht_bootstrap.go#L81-L85](https://github.com/libp2p/go-libp2p-kad-dht/blob/master/dht_bootstrap.go#L81-L85)

Worklist:

- [x] Start `random-walk` once the DHT is started
- [x] Accept configuration for disabling the default behavior