### PR TITLE
When a kad entry expires, use dsKey to remove from datastore #41

### DIFF
--- a/src/private.js
+++ b/src/private.js
@@ -133,7 +133,7 @@ module.exports = (dht) => ({
         if (record.timeReceived == null ||
             utils.now() - record.timeReceived > c.MAX_RECORD_AGE) {
           // 6. if: record is bad delete it and return
-          return dht.datastore.delete(key, callback)
+          return dht.datastore.delete(dsKey, callback)
         }
 
         //    else: return good record


### PR DESCRIPTION
fix: use dskey instead of key for removal from datastore
chore: add unit tests for _checkLocalStore of private.js

Fixes #38

License: MIT
Signed-off-by: Blake Byrnes <blakebyrnes@gmail.com>