### PR TITLE
fix: find peer and providers options

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "lint": "aegir lint",
     "test": "aegir test -t node",
+    "test:node": "aegir test -t node",
     "build": "aegir build",
     "docs": "aegir docs",
     "release": "aegir release --docs -t node",

--- a/src/index.js
+++ b/src/index.js
@@ -443,22 +443,29 @@ class KadDHT {
    * Search the dht for up to `K` providers of the given CID.
    *
    * @param {CID} key
-   * @param {number} timeout - how long the query should maximally run, in milliseconds.
+   * @param {Object} options - findProviders options
+   * @param {number} options.maxTimeout - how long the query should maximally run, in milliseconds (default: 60000)
    * @param {function(Error, Array<PeerInfo>)} callback
    * @returns {void}
    */
-  findProviders (key, timeout, callback) {
-    if (typeof timeout === 'function') {
-      callback = timeout
-      timeout = null
+  findProviders (key, options, callback) {
+    if (typeof options === 'function') {
+      callback = options
+      options = {}
+    } else if (typeof options === 'number') { // This will be deprecated in a next release
+      options = {
+        maxTimeout: options
+      }
+    } else {
+      options = options || {}
     }
 
-    if (timeout == null) {
-      timeout = c.minute
+    if (!options.maxTimeout) {
+      options.maxTimeout = c.minute
     }
 
     this._log('findProviders %s', key.toBaseEncodedString())
-    this._findNProviders(key, timeout, c.K, callback)
+    this._findNProviders(key, options.maxTimeout, c.K, callback)
   }
 
   // ----------- Peer Routing
@@ -467,18 +474,25 @@ class KadDHT {
    * Search for a peer with the given ID.
    *
    * @param {PeerId} id
-   * @param {number} [maxTimeout=60000]
+   * @param {Object} options - findPeer options
+   * @param {number} options.maxTimeout - how long the query should maximally run, in milliseconds (default: 60000)
    * @param {function(Error, PeerInfo)} callback
    * @returns {void}
    */
-  findPeer (id, maxTimeout, callback) {
-    if (typeof maxTimeout === 'function') {
-      callback = maxTimeout
-      maxTimeout = null
+  findPeer (id, options, callback) {
+    if (typeof options === 'function') {
+      callback = options
+      options = {}
+    } else if (typeof options === 'number') { // This will be deprecated in a next release
+      options = {
+        maxTimeout: options
+      }
+    } else {
+      options = options || {}
     }
 
-    if (maxTimeout == null) {
-      maxTimeout = c.minute
+    if (!options.maxTimeout) {
+      options.maxTimeout = c.minute
     }
 
     this._log('findPeer %s', id.toB58String())
@@ -534,7 +548,7 @@ class KadDHT {
 
           timeout((cb) => {
             query.run(peers, cb)
-          }, maxTimeout)(cb)
+          }, options.maxTimeout)(cb)
         },
         (result, cb) => {
           this._log('findPeer %s: %s', id.toB58String(), result.success)

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -180,7 +180,7 @@ describe('KadDHT', () => {
           let n = 0
           each(values, (v, cb) => {
             n = (n + 1) % 3
-            dhts[n].findProviders(v.cid, 5000, (err, provs) => {
+            dhts[n].findProviders(v.cid, { maxTimeout: 5000 }, (err, provs) => {
               expect(err).to.not.exist()
               expect(provs).to.have.length(1)
               expect(provs[0].id.id).to.be.eql(ids[3].id)
@@ -271,7 +271,7 @@ describe('KadDHT', () => {
         (cb) => connect(dhts[0], dhts[1], cb),
         (cb) => connect(dhts[1], dhts[2], cb),
         (cb) => connect(dhts[2], dhts[3], cb),
-        (cb) => dhts[0].findPeer(ids[3], 1000, cb),
+        (cb) => dhts[0].findPeer(ids[3], { maxTimeout: 1000 }, cb),
         (res, cb) => {
           expect(res.id.isEqual(ids[3])).to.eql(true)
           cb()


### PR DESCRIPTION
Aiming to allow other future options to `findPeer` and `findProviders`, I changed the`maxTimeout` param to an object `options`.

In the context of 
- [js-libp2p-delegated-content-routing#6](https://github.com/libp2p/js-libp2p-delegated-content-routing/pull/6)
- [js-libp2p-delegated-peer-routing#6](https://github.com/libp2p/js-libp2p-delegated-peer-routing/pull/6)