### PR TITLE
chore: upgrade libp2p record version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "interface-datastore": "~0.4.2",
     "k-bucket": "^4.0.1",
     "libp2p-crypto": "~0.13.0",
-    "libp2p-record": "~0.5.1",
+    "libp2p-record": "~0.6.0",
     "multihashes": "~0.4.14",
     "multihashing-async": "~0.5.1",
     "peer-id": "~0.11.0",

--- a/src/index.js
+++ b/src/index.js
@@ -172,15 +172,9 @@ class KadDHT {
    */
   put (key, value, callback) {
     this._log('PutValue %b', key)
-    let sign
-    try {
-      sign = libp2pRecord.validator.isSigned(this.validators, key)
-    } catch (err) {
-      return callback(err)
-    }
 
     waterfall([
-      (cb) => utils.createPutRecord(key, value, this.peerInfo.id, sign, cb),
+      (cb) => utils.createPutRecord(key, value, cb),
       (rec, cb) => waterfall([
         (cb) => this._putLocal(key, rec, cb),
         (cb) => this.getClosestPeers(key, cb),

--- a/src/rpc/handlers/get-value.js
+++ b/src/rpc/handlers/get-value.js
@@ -41,7 +41,7 @@ module.exports = (dht) => {
 
       if (info && info.id.pubKey) {
         log('returning found public key')
-        response.record = new Record(key, info.id.pubKey.bytes, dht.peerInfo.id)
+        response.record = new Record(key, info.id.pubKey.bytes)
         return callback(null, response)
       }
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -138,17 +138,12 @@ exports.xorCompare = (a, b) => {
  *
  * @param {Buffer} key
  * @param {Buffer} value
- * @param {PeerId} peer
- * @param {bool} sign - Should the record be signed
  * @param {function(Error, Buffer)} callback
  * @returns {void}
  */
-exports.createPutRecord = (key, value, peer, sign, callback) => {
-  const rec = new Record(key, value, peer)
-
-  if (sign) {
-    return rec.serializeSigned(peer.privKey, callback)
-  }
+exports.createPutRecord = (key, value, callback) => {
+  const timeReceived = new Date()
+  const rec = new Record(key, value, timeReceived)
 
   setImmediate(() => {
     callback(null, rec.serialize())

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -556,29 +556,6 @@ describe('KadDHT', () => {
   })
 
   describe('_checkLocalDatastore', () => {
-    it('valid if created by self', (done) => {
-      const sw = new Switch(peerInfos[0], new PeerBook())
-      sw.transport.add('tcp', new TCP())
-      sw.connection.addStreamMuxer(Mplex)
-      sw.connection.reuse()
-      const dht = new KadDHT(sw)
-
-      const record = new Record(
-        Buffer.from('hello'),
-        Buffer.from('world'),
-        peerInfos[0].id
-      )
-
-      waterfall([
-        (cb) => dht._putLocal(record.key, record.serialize(), cb),
-        (cb) => dht._checkLocalDatastore(record.key, cb)
-      ], (err, rec) => {
-        expect(err).to.not.exist()
-        expect(rec).to.exist('Record not located locally')
-        expect(rec.value.toString()).to.equal(record.value.toString())
-        done()
-      })
-    })
     it('allow a peer record from store if recent', (done) => {
       const sw = new Switch(peerInfos[0], new PeerBook())
       sw.transport.add('tcp', new TCP())
@@ -588,8 +565,7 @@ describe('KadDHT', () => {
 
       const record = new Record(
         Buffer.from('hello'),
-        Buffer.from('world'),
-        peerInfos[1].id
+        Buffer.from('world')
       )
       record.timeReceived = new Date()
 
@@ -612,8 +588,7 @@ describe('KadDHT', () => {
 
       const record = new Record(
         Buffer.from('hello'),
-        Buffer.from('world'),
-        peerInfos[1].id
+        Buffer.from('world')
       )
       let received = new Date()
       received.setDate(received.getDate() - 2)
@@ -642,32 +617,7 @@ describe('KadDHT', () => {
   })
 
   describe('_verifyRecordLocally', () => {
-    it('invalid record (missing public key)', (done) => {
-      const sw = new Switch(peerInfos[0], new PeerBook())
-      sw.transport.add('tcp', new TCP())
-      sw.connection.addStreamMuxer(Mplex)
-      sw.connection.reuse()
-      const dht = new KadDHT(sw)
-
-      // Not putting the peer info into the peerbook
-      // dht.peerBook.put(peerInfos[1])
-
-      const record = new Record(
-        Buffer.from('hello'),
-        Buffer.from('world'),
-        peerInfos[1].id
-      )
-
-      waterfall([
-        (cb) => record.serializeSigned(peerInfos[1].id.privKey, cb),
-        (enc, cb) => dht._verifyRecordLocally(Record.deserialize(enc), (err) => {
-          expect(err).to.match(/Missing public key/)
-          cb()
-        })
-      ], done)
-    })
-
-    it('valid record - signed', (done) => {
+    it('valid record', (done) => {
       const sw = new Switch(peerInfos[0], new PeerBook())
       sw.transport.add('tcp', new TCP())
       sw.connection.addStreamMuxer(Mplex)
@@ -678,29 +628,7 @@ describe('KadDHT', () => {
 
       const record = new Record(
         Buffer.from('hello'),
-        Buffer.from('world'),
-        peerInfos[1].id
-      )
-
-      waterfall([
-        (cb) => record.serializeSigned(peerInfos[1].id.privKey, cb),
-        (enc, cb) => dht._verifyRecordLocally(Record.deserialize(enc), cb)
-      ], done)
-    })
-
-    it('valid record - not signed', (done) => {
-      const sw = new Switch(peerInfos[0], new PeerBook())
-      sw.transport.add('tcp', new TCP())
-      sw.connection.addStreamMuxer(Mplex)
-      sw.connection.reuse()
-      const dht = new KadDHT(sw)
-
-      dht.peerBook.put(peerInfos[1])
-
-      const record = new Record(
-        Buffer.from('hello'),
-        Buffer.from('world'),
-        peerInfos[1].id
+        Buffer.from('world')
       )
 
       waterfall([

--- a/test/message.spec.js
+++ b/test/message.spec.js
@@ -51,7 +51,7 @@ describe('Message', () => {
       })
 
       const msg = new Message(Message.TYPES.GET_VALUE, Buffer.from('hello'), 5)
-      const record = new Record(Buffer.from('hello'), Buffer.from('world'), peers[0])
+      const record = new Record(Buffer.from('hello'), Buffer.from('world'))
 
       msg.closerPeers = closer
       msg.providerPeers = provider
@@ -104,7 +104,6 @@ describe('Message', () => {
       expect(msg.clusterLevel).to.gte(0)
       if (msg.record) {
         expect(Buffer.isBuffer(msg.record.key)).to.eql(true)
-        expect(PeerId.isPeerId(msg.record.author)).to.eql(true)
       }
 
       if (msg.providerPeers.length > 0) {

--- a/test/rpc/handlers/get-value.spec.js
+++ b/test/rpc/handlers/get-value.spec.js
@@ -56,7 +56,6 @@ describe('rpc - handlers - GetValue', () => {
     const key = Buffer.from('hello')
     const value = Buffer.from('world')
     const msg = new Message(T, key, 0)
-
     waterfall([
       (cb) => dht.put(key, value, cb),
       (cb) => handler(dht)(peers[0], msg, cb)

--- a/test/rpc/handlers/put-value.spec.js
+++ b/test/rpc/handlers/put-value.spec.js
@@ -56,8 +56,7 @@ describe('rpc - handlers - PutValue', () => {
     const msg = new Message(T, Buffer.from('hello'), 5)
     const record = new Record(
       Buffer.from('hello'),
-      Buffer.from('world'),
-      peers[0].id
+      Buffer.from('world')
     )
     msg.record = record
 


### PR DESCRIPTION
The `libp2p-record` module was updated to interop with `go-libp2p-record`.  As a result, the author and signature were removed, as well as all the logic inherent to the signature.

More info [js-libp2p-record#8](https://github.com/libp2p/js-libp2p-record/pull/8)