### PR TITLE
fix: record outdated local correction

### DIFF
--- a/src/private.js
+++ b/src/private.js
@@ -299,7 +299,7 @@ module.exports = (dht) => ({
             }
 
             // send correction
-            dht._putValueToPeer(v.from, key, fixupRec, (err) => {
+            dht._putValueToPeer(key, fixupRec, v.from, (err) => {
               if (err) {
                 dht._log.error('Failed error correcting entry', err)
               }

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -246,7 +246,9 @@ describe('KadDHT', () => {
           (cb) => dhtC.get(Buffer.from('/v/hello'), { maxTimeout: 1000 }, cb)
         ], (err, res) => {
           expect(err).to.not.exist()
-          expect(res).to.exist()
+          expect(res[0]).to.eql(Buffer.from('worldA'))
+          expect(res[1]).to.eql(Buffer.from('worldB'))
+          expect(res[2]).to.eql(Buffer.from('worldC'))
           tdht.teardown(done)
         })
       })

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -222,6 +222,32 @@ describe('KadDHT', () => {
     })
   })
 
+  it('put - get with update', function (done) {
+    this.timeout(10 * 1000)
+    const tdht = new TestDHT()
+
+    tdht.spawn(3, (err, dhts) => {
+      expect(err).to.not.exist()
+      const dhtA = dhts[0]
+      const dhtB = dhts[1]
+      const dhtC = dhts[1]
+
+      waterfall([
+        (cb) => connect(dhtA, dhtB, cb),
+        (cb) => dhtA.put(Buffer.from('/v/hello'), Buffer.from('world'), cb),
+        (cb) => dhtB.put(Buffer.from('/v/hello'), Buffer.from('world2'), cb),
+        (cb) => dhtC.get(Buffer.from('/v/hello'), { maxTimeout: 1000 }, cb),
+        (res, cb) => {
+          expect(res).to.eql(Buffer.from('world2'))
+          cb()
+        }
+      ], (err) => {
+        expect(err).to.not.exist()
+        tdht.teardown(done)
+      })
+    })
+  })
+
   it('provides', function (done) {
     this.timeout(20 * 1000)
 

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -230,10 +230,11 @@ describe('KadDHT', () => {
       expect(err).to.not.exist()
       const dhtA = dhts[0]
       const dhtB = dhts[1]
-      const dhtC = dhts[1]
+      const dhtC = dhts[2]
 
       waterfall([
         (cb) => connect(dhtA, dhtB, cb),
+        (cb) => connect(dhtA, dhtC, cb),
         (cb) => dhtA.put(Buffer.from('/v/hello'), Buffer.from('world'), cb),
         (cb) => dhtB.put(Buffer.from('/v/hello'), Buffer.from('world2'), cb),
         (cb) => dhtC.get(Buffer.from('/v/hello'), { maxTimeout: 1000 }, cb),

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -232,19 +232,23 @@ describe('KadDHT', () => {
       const dhtB = dhts[1]
       const dhtC = dhts[2]
 
-      waterfall([
+      parallel([
         (cb) => connect(dhtA, dhtB, cb),
         (cb) => connect(dhtA, dhtC, cb),
-        (cb) => dhtA.put(Buffer.from('/v/hello'), Buffer.from('world'), cb),
-        (cb) => dhtB.put(Buffer.from('/v/hello'), Buffer.from('world2'), cb),
-        (cb) => dhtC.get(Buffer.from('/v/hello'), { maxTimeout: 1000 }, cb),
-        (res, cb) => {
-          expect(res).to.eql(Buffer.from('world2'))
-          cb()
-        }
+        (cb) => dhtA.put(Buffer.from('/v/hello'), Buffer.from('worldA'), cb),
+        (cb) => dhtB.put(Buffer.from('/v/hello'), Buffer.from('worldB'), cb),
+        (cb) => dhtC.put(Buffer.from('/v/hello'), Buffer.from('worldC'), cb)
       ], (err) => {
         expect(err).to.not.exist()
-        tdht.teardown(done)
+        parallel([
+          (cb) => dhtA.get(Buffer.from('/v/hello'), { maxTimeout: 1000 }, cb),
+          (cb) => dhtB.get(Buffer.from('/v/hello'), { maxTimeout: 1000 }, cb),
+          (cb) => dhtC.get(Buffer.from('/v/hello'), { maxTimeout: 1000 }, cb)
+        ], (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          tdht.teardown(done)
+        })
       })
     })
   })


### PR DESCRIPTION
`dht._putValueToPeer` was receiving the parameters in a wrong order, for this case.