### PR TITLE
tests: multiple nodes

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,4 +1,4 @@
 module.exports = {
-    bundlesize: { maxSize: '192kB' }
+    bundlesize: { maxSize: '196kB' }
 }
   


### PR DESCRIPTION
Added tests using 8 different nodes, in order to create some stress in the DHT.

During this tests, I found a bug regarding the local correction of outdated records. This way, the tests for this PR fail sometimes while the following PR is not merged:

- [x] [js-libp2p-kad-dht/pull/49](https://github.com/libp2p/js-libp2p-kad-dht/pull/49)