### PR TITLE
fix: specify # of peers for successful put

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const libp2pRecord = require('libp2p-record')
 const MemoryStore = require('interface-datastore').MemoryDatastore
 const waterfall = require('async/waterfall')
 const each = require('async/each')
+const filter = require('async/filter')
 const timeout = require('async/timeout')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
@@ -181,7 +182,7 @@ class KadDHT {
    * @param {Buffer} value
    * @param {Object} options - get options
    * @param {number} options.minPeers - minimum peers that must be put to to consider this a successful operation
-   * (default: 0)
+   * (default: closestPeers.length)
    * @param {function(Error)} callback
    * @returns {void}
    */
@@ -192,42 +193,41 @@ class KadDHT {
     } else {
       options = options || {}
     }
-    if (!options.minPeers) {
-      options.minPeers = 0 // default
-    }
-    this._log('PutValue %b', key)
 
-    let counter = 0
+    this._log('PutValue %b', key)
 
     waterfall([
       (cb) => utils.createPutRecord(key, value, cb),
       (rec, cb) => waterfall([
         (cb) => this._putLocal(key, rec, cb),
         (cb) => this.getClosestPeers(key, cb),
-        (peers, cb) => each(peers, (peer, cb) => {
-          this._putValueToPeer(key, rec, peer, (err) => {
-            if (err) {
-              this._log.error('Failed to put to peer (%b): %s', peer.id, err)
-            } else {
-              counter += 1
+        (peers, cb) => {
+          // Ensure we have a default `minPeers`
+          options.minPeers = options.minPeers || peers.length
+          // filter out the successful puts
+          filter(peers, (peer, cb) => {
+            this._putValueToPeer(key, rec, peer, (err) => {
+              if (err) {
+                this._log.error('Failed to put to peer (%b): %s', peer.id, err)
+                return cb(null, false)
+              }
+              cb(null, true)
+            })
+          }, (err, results) => {
+            if (err) return cb(err)
+
+            // Did we put to enough peers?
+            if (options.minPeers > results.length) {
+              const error = errcode(new Error('Failed to put value to enough peers'), 'ERR_NOT_ENOUGH_PUT_PEERS')
+              this._log.error(error)
+              return cb(error)
             }
-            // always ok result
+
             cb()
           })
-        }, cb)
+        }
       ], cb)
-    ], (err) => {
-      if (err) {
-        return callback(err)
-      }
-      if (counter < options.minPeers) {
-        const errMsg = 'Failed to put value to enough peers'
-
-        this._log.error(errMsg)
-        return callback(errcode(new Error(errMsg), 'ERR_NOT_ENOUGH_PUT_PEERS'))
-      }
-      callback()
-    })
+    ], callback)
   }
 
   /**

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -280,6 +280,75 @@ describe('KadDHT', () => {
     })
   })
 
+  it('put - should require a minimum number of peers to have successful puts', function (done) {
+    this.timeout(10 * 1000)
+    const tdht = new TestDHT()
+
+    const errCode = 'ERR_NOT_AVAILABLE'
+    const error = errcode(new Error('fake error'), errCode)
+
+    tdht.spawn(4, (err, dhts) => {
+      expect(err).to.not.exist()
+      const dhtA = dhts[0]
+      const dhtB = dhts[1]
+      const dhtC = dhts[2]
+      const dhtD = dhts[3]
+      const stub = sinon.stub(dhtD, '_verifyRecordLocally').callsArgWithAsync(1, error)
+
+      waterfall([
+        (cb) => connect(dhtA, dhtB, cb),
+        (cb) => connect(dhtA, dhtC, cb),
+        (cb) => connect(dhtA, dhtD, cb),
+        (cb) => dhtA.put(Buffer.from('/v/hello'), Buffer.from('world'), { minPeers: 2 }, cb),
+        (cb) => dhtB.get(Buffer.from('/v/hello'), { timeout: 1000 }, cb),
+        (res, cb) => {
+          expect(res).to.eql(Buffer.from('world'))
+          cb()
+        }
+      ], (err) => {
+        expect(err).to.not.exist()
+        stub.restore()
+        tdht.teardown(done)
+      })
+    })
+  })
+
+  it('put - should fail if not enough peers can be written to', function (done) {
+    this.timeout(10 * 1000)
+    const tdht = new TestDHT()
+
+    const errCode = 'ERR_NOT_AVAILABLE'
+    const error = errcode(new Error('fake error'), errCode)
+
+    tdht.spawn(4, (err, dhts) => {
+      expect(err).to.not.exist()
+      const dhtA = dhts[0]
+      const dhtB = dhts[1]
+      const dhtC = dhts[2]
+      const dhtD = dhts[3]
+      const stub = sinon.stub(dhtD, '_verifyRecordLocally').callsArgWithAsync(1, error)
+      const stub2 = sinon.stub(dhtC, '_verifyRecordLocally').callsArgWithAsync(1, error)
+
+      waterfall([
+        (cb) => connect(dhtA, dhtB, cb),
+        (cb) => connect(dhtA, dhtC, cb),
+        (cb) => connect(dhtA, dhtD, cb),
+        (cb) => dhtA.put(Buffer.from('/v/hello'), Buffer.from('world'), { minPeers: 2 }, cb),
+        (cb) => dhtB.get(Buffer.from('/v/hello'), { timeout: 1000 }, cb),
+        (res, cb) => {
+          expect(res).to.eql(Buffer.from('world'))
+          cb()
+        }
+      ], (err) => {
+        expect(err).to.exist()
+        expect(err.code).to.eql('ERR_NOT_ENOUGH_PUT_PEERS')
+        stub.restore()
+        stub2.restore()
+        tdht.teardown(done)
+      })
+    })
+  })
+
   it('put - get using key with no prefix (no selector available)', function (done) {
     this.timeout(10 * 1000)
     const tdht = new TestDHT()
@@ -853,7 +922,7 @@ describe('KadDHT', () => {
       tdht.spawn(nDHTs, (err, dhts) => {
         expect(err).to.not.exist()
 
-        dhts[0].getMany('/v/hello', 5, (err) => {
+        dhts[0].getMany(Buffer.from('/v/hello'), 5, (err) => {
           expect(err).to.exist()
           expect(err.code).to.be.eql('ERR_NO_PEERS_IN_ROUTING_TABLE')
           tdht.teardown(done)


### PR DESCRIPTION
put call fails if any node fails for any reason - including disconnected, node doesn’t support kad protocol, etc.  Changed behavior to be able to provide a minimum number of peers to write to to be considered a “successful put”.  Default put peers required was chosen as 0 so as to be a non-breaking change

Fix for #68 