### PR TITLE
refactor: default to CID v1 and encode with base32

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "async": "^2.6.2",
     "base32.js": "~0.1.0",
     "chai-checkmark": "^1.0.1",
-    "cids": "~0.5.7",
+    "cids": "github:multiformats/js-cid#refactor/cidv1base32-default",
     "debug": "^4.1.1",
     "err-code": "^1.1.2",
     "hashlru": "^2.3.0",


### PR DESCRIPTION
BREAKING CHANGE: Any CIDs created and returned by this module are base32 encoded by default when stringified.

Depends on:

* [ ] https://github.com/multiformats/js-cid/pull/73