### PR TITLE
fix: not emit peer discovery event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { EventEmitter } = require('events')
 const libp2pRecord = require('libp2p-record')
 const MemoryStore = require('interface-datastore').MemoryDatastore
 const waterfall = require('async/waterfall')
@@ -30,7 +29,7 @@ const defaultsDeep = require('@nodeutils/defaults-deep')
  *
  * Original implementation in go: https://github.com/libp2p/go-libp2p-kad-dht.
  */
-class KadDHT extends EventEmitter {
+class KadDHT {
   /**
    * Random walk options
    *
@@ -53,7 +52,6 @@ class KadDHT extends EventEmitter {
    * @param {randomWalkOptions} options.randomWalk randomWalk options
    */
   constructor (sw, options) {
-    super()
     assert(sw, 'libp2p-kad-dht requires a instance of Switch')
     options = options || {}
     options.validators = options.validators || {}
@@ -668,10 +666,6 @@ class KadDHT extends EventEmitter {
         }
       ], callback)
     })
-  }
-
-  _peerDiscovered (peerInfo) {
-    this.emit('peer', peerInfo)
   }
 }
 

--- a/src/network.js
+++ b/src/network.js
@@ -122,8 +122,6 @@ class Network {
           return this._log.error('Failed to add to the routing table', err)
         }
 
-        this.dht._peerDiscovered(peer)
-
         this._log('added to the routing table: %s', peer.id.toB58String())
       })
     })

--- a/src/query.js
+++ b/src/query.js
@@ -206,7 +206,6 @@ function execQuery (next, query, path, callback) {
           return cb()
         }
         closer = query.dht.peerBook.put(closer)
-        query.dht._peerDiscovered(closer)
         addPeerToQuery(closer.id, query.dht, path, cb)
       }, callback)
     } else {

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -257,31 +257,6 @@ describe('KadDHT', () => {
     })
   })
 
-  it('should emit a peer event when a peer is connected', function (done) {
-    this.timeout(10 * 1000)
-    const tdht = new TestDHT()
-
-    tdht.spawn(2, (err, dhts) => {
-      expect(err).to.not.exist()
-      const dhtA = dhts[0]
-      const dhtB = dhts[1]
-
-      dhtA.on('peer', (peerInfo) => {
-        expect(peerInfo).to.exist().mark()
-      })
-
-      dhtB.on('peer', (peerInfo) => {
-        expect(peerInfo).to.exist().mark()
-      })
-
-      connect(dhtA, dhtB, (err) => {
-        expect(err).to.not.exist()
-      })
-    })
-
-    expect(2).checks(done)
-  })
-
   it('put - get', function (done) {
     this.timeout(10 * 1000)
     const tdht = new TestDHT()


### PR DESCRIPTION
`kad-dht` does not need to emit the `peer-discovery` event since it already dials to the peers.