### PR TITLE
fix: false discovery

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -122,8 +122,6 @@ class Network {
           return this._log.error('Failed to add to the routing table', err)
         }
 
-        this.dht._peerDiscovered(peer)
-
         this._log('added to the routing table: %s', peer.id.toB58String())
       })
     })

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -257,31 +257,6 @@ describe('KadDHT', () => {
     })
   })
 
-  it('should emit a peer event when a peer is connected', function (done) {
-    this.timeout(10 * 1000)
-    const tdht = new TestDHT()
-
-    tdht.spawn(2, (err, dhts) => {
-      expect(err).to.not.exist()
-      const dhtA = dhts[0]
-      const dhtB = dhts[1]
-
-      dhtA.on('peer', (peerInfo) => {
-        expect(peerInfo).to.exist().mark()
-      })
-
-      dhtB.on('peer', (peerInfo) => {
-        expect(peerInfo).to.exist().mark()
-      })
-
-      connect(dhtA, dhtB, (err) => {
-        expect(err).to.not.exist()
-      })
-    })
-
-    expect(2).checks(done)
-  })
-
   it('put - get', function (done) {
     this.timeout(10 * 1000)
     const tdht = new TestDHT()

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -157,4 +157,27 @@ describe('Query', () => {
       })
     })
   })
+
+  it('should discover closer peers', (done) => {
+    const peer = peerInfos[0]
+
+    // mock this so we can dial non existing peers
+    dht.switch.dial = (peer, callback) => callback()
+
+    const query = (p, cb) => {
+      cb(null, {
+        closerPeers: [peerInfos[2]]
+      })
+    }
+
+    const q = new Query(dht, peer.id.id, () => query)
+    q.run([peerInfos[1].id], (err, res) => {
+      expect(err).to.not.exist()
+    })
+
+    dht.once('peer', (peerInfo) => {
+      expect(peerInfo.id).to.eql(peerInfos[2].id)
+      done()
+    })
+  })
 })


### PR DESCRIPTION
This PR prevents the DHT claiming discovery of a peer that it may not have even discovered and also multiple discoveries of the same peer.

DHT was listening for 'peer-mux-established' from the switch and emitting a 'peer' event in response to it. Listening to 'peer-mux-established' implies that the peer has _already_ been discovered so there's no need to emit it again and moreover the peer may not have been discovered by the DHT in the first place!