### PR TITLE
Ensure queries stop after error or success

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -359,7 +359,7 @@ class KadDHT extends EventEmitter {
 
                 // enough is enough
                 if (pathVals.length >= pathSize) {
-                  res.success = true
+                  res.pathComplete = true
                 }
 
                 cb(null, res)
@@ -368,7 +368,12 @@ class KadDHT extends EventEmitter {
           })
 
           // run our query
-          timeout((cb) => query.run(rtp, cb), options.timeout)(cb)
+          timeout((_cb) => {
+            query.run(rtp, _cb)
+          }, options.timeout)((err, res) => {
+            query.stop()
+            cb(err, res)
+          })
         }
       ], (err) => {
         // combine vals from each path
@@ -419,7 +424,7 @@ class KadDHT extends EventEmitter {
             (closer, cb) => {
               cb(null, {
                 closerPeers: closer,
-                success: options.shallow ? true : undefined
+                pathComplete: options.shallow ? true : undefined
               })
             }
           ], callback)
@@ -636,7 +641,7 @@ class KadDHT extends EventEmitter {
                   if (match) {
                     return cb(null, {
                       peer: match,
-                      success: true
+                      queryComplete: true
                     })
                   }
 
@@ -648,9 +653,12 @@ class KadDHT extends EventEmitter {
             }
           })
 
-          timeout((cb) => {
-            query.run(peers, cb)
-          }, options.timeout)(cb)
+          timeout((_cb) => {
+            query.run(peers, _cb)
+          }, options.timeout)((err, res) => {
+            query.stop()
+            cb(err, res)
+          })
         },
         (result, cb) => {
           let success = false

--- a/src/private.js
+++ b/src/private.js
@@ -510,7 +510,7 @@ module.exports = (dht) => ({
 
               // hooray we have all that we want
               if (pathProviders.length >= pathSize) {
-                return cb(null, { success: true })
+                return cb(null, { pathComplete: true })
               }
 
               // it looks like we want some more
@@ -525,6 +525,8 @@ module.exports = (dht) => ({
       const peers = dht.routingTable.closestPeers(key.buffer, c.ALPHA)
 
       timeout((cb) => query.run(peers, cb), providerTimeout)((err) => {
+        query.stop()
+
         // combine peers from each path
         paths.forEach((path) => {
           path.toArray().forEach((peer) => {

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -8,6 +8,7 @@ const PeerBook = require('peer-book')
 const Switch = require('libp2p-switch')
 const TCP = require('libp2p-tcp')
 const Mplex = require('libp2p-mplex')
+const setImmediate = require('async/setImmediate')
 
 const DHT = require('../src')
 const Query = require('../src/query')
@@ -21,7 +22,7 @@ describe('Query', () => {
 
   before(function (done) {
     this.timeout(5 * 1000)
-    createPeerInfo(10, (err, result) => {
+    createPeerInfo(12, (err, result) => {
       if (err) {
         return done(err)
       }
@@ -50,7 +51,7 @@ describe('Query', () => {
 
         return cb(null, {
           value: Buffer.from('cool'),
-          success: true
+          pathComplete: true
         })
       }
       expect(p.id).to.eql(peerInfos[1].id.id)
@@ -65,6 +66,37 @@ describe('Query', () => {
       expect(res.paths[0].value).to.eql(Buffer.from('cool'))
       expect(res.paths[0].success).to.eql(true)
       expect(res.finalSet.size).to.eql(2)
+      done()
+    })
+  })
+
+  it('does not return an error if only some queries error', (done) => {
+    const peer = peerInfos[0]
+
+    // mock this so we can dial non existing peers
+    dht.switch.dial = (peer, callback) => callback()
+
+    let i = 0
+    const query = (p, cb) => {
+      if (i++ === 1) {
+        return cb(new Error('fail'))
+      }
+      cb(null, {
+        closerPeers: [peerInfos[2]]
+      })
+    }
+
+    const q = new Query(dht, peer.id.id, () => query)
+    q.run([peerInfos[1].id], (err, res) => {
+      expect(err).not.to.exist()
+
+      // Should have visited
+      // - the initial peer passed to the query: peerInfos[1]
+      // - the peer returned in closerPeers: peerInfos[2]
+      expect(res.finalSet.size).to.eql(2)
+      expect(res.finalSet.has(peerInfos[1].id)).to.equal(true)
+      expect(res.finalSet.has(peerInfos[2].id)).to.equal(true)
+
       done()
     })
   })
@@ -105,6 +137,309 @@ describe('Query', () => {
     })
   })
 
+  it('only closerPeers concurrent', (done) => {
+    const peer = peerInfos[0]
+
+    // mock this so we can dial non existing peers
+    dht.switch.dial = (peer, callback) => callback()
+
+    //  1 -> 8
+    //  2 -> 4 -> 5
+    //       6 -> 7
+    //  3 -> 9 -> 10
+    const topology = {
+      [peerInfos[1].id.toB58String()]: [
+        peerInfos[8]
+      ],
+
+      [peerInfos[2].id.toB58String()]: [
+        peerInfos[4],
+        peerInfos[6]
+      ],
+      [peerInfos[4].id.toB58String()]: [
+        peerInfos[5]
+      ],
+      [peerInfos[6].id.toB58String()]: [
+        peerInfos[7]
+      ],
+
+      [peerInfos[3].id.toB58String()]: [
+        peerInfos[9]
+      ],
+      [peerInfos[9].id.toB58String()]: [
+        peerInfos[10]
+      ]
+    }
+
+    const query = (p, cb) => {
+      const closer = topology[p.toB58String()]
+      cb(null, {
+        closerPeers: closer || []
+      })
+    }
+
+    const q = new Query(dht, peer.id.id, () => query)
+    q.run([peerInfos[1].id, peerInfos[2].id, peerInfos[3].id], (err, res) => {
+      expect(err).to.not.exist()
+
+      // Should visit all peers
+      expect(res.finalSet.size).to.eql(10)
+      done()
+    })
+  })
+
+  it('early success', (done) => {
+    const peer = peerInfos[0]
+
+    // mock this so we can dial non existing peers
+    dht.switch.dial = (peer, callback) => callback()
+
+    // 1 -> 2 -> 3 -> 4
+    const topology = {
+      [peerInfos[1].id.toB58String()]: {
+        closer: [peerInfos[2]]
+      },
+      // Should stop here because pathComplete is true
+      [peerInfos[2].id.toB58String()]: {
+        closer: [peerInfos[3]],
+        pathComplete: true
+      },
+      // Should not reach here because previous query returns pathComplete
+      [peerInfos[3].id.toB58String()]: {
+        closer: [peerInfos[4]]
+      }
+    }
+
+    const query = (p, cb) => {
+      const res = topology[p.toB58String()] || {}
+      cb(null, {
+        closerPeers: res.closer || [],
+        value: res.value,
+        pathComplete: res.pathComplete
+      })
+    }
+
+    const q = new Query(dht, peer.id.id, () => query)
+    q.run([peerInfos[1].id], (err, res) => {
+      expect(err).to.not.exist()
+
+      // Should complete successfully
+      expect(res.paths.length).to.eql(1)
+      expect(res.paths[0].success).to.eql(true)
+
+      // Should only visit peers up to the success peer
+      expect(res.finalSet.size).to.eql(2)
+
+      done()
+    })
+  })
+
+  it('disjoint path values', (done) => {
+    const peer = peerInfos[0]
+    const values = ['v0', 'v1'].map(Buffer.from)
+
+    // mock this so we can dial non existing peers
+    dht.switch.dial = (peer, callback) => callback()
+
+    // 1 -> 2 -> 3 (v0)
+    // 4 -> 5 (v1)
+    const topology = {
+      // Top level node
+      [peerInfos[1].id.toB58String()]: {
+        closer: [peerInfos[2]]
+      },
+      [peerInfos[2].id.toB58String()]: {
+        closer: [peerInfos[3]]
+      },
+      // v0
+      [peerInfos[3].id.toB58String()]: {
+        value: values[0],
+        pathComplete: true
+      },
+
+      // Top level node
+      [peerInfos[4].id.toB58String()]: {
+        closer: [peerInfos[5]]
+      },
+      // v1
+      [peerInfos[5].id.toB58String()]: {
+        value: values[1],
+        pathComplete: true
+      }
+    }
+
+    const query = (p, cb) => {
+      const res = topology[p.toB58String()] || {}
+      setTimeout(() => {
+        cb(null, {
+          closerPeers: res.closer || [],
+          value: res.value,
+          pathComplete: res.pathComplete
+        })
+      }, res.delay)
+    }
+
+    const q = new Query(dht, peer.id.id, () => query)
+    q.run([peerInfos[1].id, peerInfos[4].id], (err, res) => {
+      expect(err).to.not.exist()
+
+      // We should get back the values from both paths
+      expect(res.paths.length).to.eql(2)
+      expect(res.paths[0].value).to.eql(values[0])
+      expect(res.paths[0].success).to.eql(true)
+      expect(res.paths[1].value).to.eql(values[1])
+      expect(res.paths[1].success).to.eql(true)
+
+      done()
+    })
+  })
+
+  it('disjoint path values with early completion', (done) => {
+    const peer = peerInfos[0]
+    const values = ['v0', 'v1'].map(Buffer.from)
+
+    // mock this so we can dial non existing peers
+    dht.switch.dial = (peer, callback) => callback()
+
+    // 1 -> 2 (delay) -> 3
+    // 4 -> 5 [query complete]
+    const topology = {
+      // Top level node
+      [peerInfos[1].id.toB58String()]: {
+        closer: [peerInfos[2]]
+      },
+      // This query has a delay which means it only returns after the other
+      // path has already indicated the query is complete, so its result
+      // should be ignored
+      [peerInfos[2].id.toB58String()]: {
+        delay: 100,
+        closer: [peerInfos[3]]
+      },
+      // Query has stopped by the time we reach here, should be ignored
+      [peerInfos[3].id.toB58String()]: {
+        value: values[0],
+        pathComplete: true
+      },
+
+      // Top level node
+      [peerInfos[4].id.toB58String()]: {
+        closer: [peerInfos[5]]
+      },
+      // This peer indicates that the query is complete
+      [peerInfos[5].id.toB58String()]: {
+        closer: [peerInfos[2]],
+        value: values[1],
+        queryComplete: true
+      }
+    }
+
+    const visited = []
+    const query = (p, cb) => {
+      visited.push(p)
+
+      const res = topology[p.toB58String()] || {}
+      setTimeout(() => {
+        cb(null, {
+          closerPeers: res.closer || [],
+          value: res.value,
+          pathComplete: res.pathComplete,
+          queryComplete: res.queryComplete
+        })
+      }, res.delay)
+    }
+
+    const q = new Query(dht, peer.id.id, () => query)
+    q.run([peerInfos[1].id, peerInfos[4].id], (err, res) => {
+      expect(err).to.not.exist()
+
+      // We should only get back the value from the path 4 -> 5
+      expect(res.paths.length).to.eql(1)
+      expect(res.paths[0].value).to.eql(values[1])
+      expect(res.paths[0].success).to.eql(true)
+
+      // Wait a little bit to make sure we don't continue down another path
+      // after finding a successful path
+      setTimeout(() => {
+        if (visited.indexOf(peerInfos[3].id) !== -1) {
+          expect.fail('Query continued after success was returned')
+        }
+        done()
+      }, 300)
+    })
+  })
+
+  it('disjoint path continue other paths after error on one path', (done) => {
+    const peer = peerInfos[0]
+    const values = ['v0', 'v1'].map(Buffer.from)
+
+    // mock this so we can dial non existing peers
+    dht.switch.dial = (peer, callback) => callback()
+
+    // 1 -> 2 (delay) -> 3 [pathComplete]
+    // 4 -> 5 [error] -> 6
+    const topology = {
+      // Top level node
+      [peerInfos[1].id.toB58String()]: {
+        closer: [peerInfos[2]]
+      },
+      // This query has a delay which means it only returns after the other
+      // path has already returned an error
+      [peerInfos[2].id.toB58String()]: {
+        delay: 100,
+        closer: [peerInfos[3]]
+      },
+      // Success peer, should get this value back at the end
+      [peerInfos[3].id.toB58String()]: {
+        value: values[0],
+        pathComplete: true
+      },
+
+      // Top level node
+      [peerInfos[4].id.toB58String()]: {
+        closer: [peerInfos[5]]
+      },
+      // Return an error at this point
+      [peerInfos[5].id.toB58String()]: {
+        closer: [peerInfos[6]],
+        error: true
+      },
+      // Should never reach here
+      [peerInfos[6].id.toB58String()]: {
+        value: values[1],
+        pathComplete: true
+      }
+    }
+
+    const visited = []
+    const query = (p, cb) => {
+      visited.push(p)
+
+      const res = topology[p.toB58String()] || {}
+      setTimeout(() => {
+        if (res.error) {
+          return cb(new Error('path error'))
+        }
+        cb(null, {
+          closerPeers: res.closer || [],
+          value: res.value,
+          pathComplete: res.pathComplete
+        })
+      }, res.delay)
+    }
+
+    const q = new Query(dht, peer.id.id, () => query)
+    q.run([peerInfos[1].id, peerInfos[4].id], (err, res) => {
+      expect(err).to.not.exist()
+
+      // We should only get back the value from the path 1 -> 2 -> 3
+      expect(res.paths.length).to.eql(1)
+      expect(res.paths[0].value).to.eql(values[0])
+      expect(res.paths[0].success).to.eql(true)
+
+      done()
+    })
+  })
+
   /*
    * This test creates two disjoint tracks of peers, one for
    * each of the query's two paths to follow. The "good"
@@ -130,18 +465,20 @@ describe('Query', () => {
       // mock this so we can dial non existing peers
       dht.switch.dial = (peer, callback) => callback()
       let badEndVisited = false
+      let targetVisited = false
 
       const q = new Query(dht, targetId, (trackNum) => {
         return (p, cb) => {
           const response = getResponse(p, trackNum)
           expect(response).to.exist() // or we aren't on the right track
-          if (response.end && !response.success) {
+          if (response.end && !response.pathComplete) {
             badEndVisited = true
           }
-          if (response.success) {
+          if (response.pathComplete) {
+            targetVisited = true
             expect(badEndVisited).to.eql(false)
           }
-          cb(null, response)
+          setImmediate(() => cb(null, response))
         }
       })
       q.concurrency = 1
@@ -149,6 +486,8 @@ describe('Query', () => {
       // path is good, second bad
       q.run(starts, (err, res) => {
         expect(err).to.not.exist()
+        // we should reach the target node
+        expect(targetVisited).to.eql(true)
         // we should visit all nodes (except the target)
         expect(res.finalSet.size).to.eql(peerInfos.length - 1)
         // there should be one successful path

--- a/test/utils/create-disjoint-tracks.js
+++ b/test/utils/create-disjoint-tracks.js
@@ -70,10 +70,10 @@ function createDisjointTracks (peerInfos, goodLength, callback) {
         const nextPos = pos + 1
         // if we're at the end of the track
         if (nextPos === track.length) {
-          if (trackNum === 0) { // good track; success
+          if (trackNum === 0) { // good track; pathComplete
             return {
               end: true,
-              success: true
+              pathComplete: true
             }
           } else { // bad track; dead end
             return {


### PR DESCRIPTION
Currently queries continue running
- after there was a timeout
- after a match is found on one disjoint path (eg in find peer)

This PR changes the query function to return either `pathComplete` or `queryComplete`, where `queryComplete` indicates that the whole query should stop (not just this particular disjoint path)

It also ensures that queries are stopped after a timeout or any other error.