### PR TITLE
feat: add delay support to random walk

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -44,5 +44,6 @@ exports.defaultRandomWalk = {
   enabled: true,
   queriesPerPeriod: 1,
   interval: 5 * minute,
-  timeout: 10 * second
+  timeout: 10 * second,
+  delay: 10 * second
 }

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -74,8 +74,7 @@ function connect (a, b, callback) {
 
 function bootstrap (dhts) {
   dhts.forEach((dht) => {
-    // dht.randomWalk._walk(3, 10000, () => {}) // don't need to know when it finishes
-    dht.randomWalk.start(1, 1000) // don't need to know when it finishes
+    dht.randomWalk._walk(1, 1000, () => {})
   })
 }
 
@@ -212,7 +211,7 @@ describe('KadDHT', () => {
       (cb) => dht.start(cb),
       (cb) => {
         expect(dht.network.start.calledOnce).to.equal(true)
-        expect(dht.randomWalk.start.calledOnce).to.equal(false)
+        expect(dht.randomWalk._runningHandle).to.not.exist()
 
         cb()
       },
@@ -567,13 +566,17 @@ describe('KadDHT', () => {
   })
 
   it('random-walk', function (done) {
-    this.timeout(40 * 1000)
+    this.timeout(10 * 1000)
 
     const nDHTs = 20
     const tdht = new TestDHT()
 
     // random walk disabled for a manual usage
-    tdht.spawn(nDHTs, { enabledDiscovery: false }, (err, dhts) => {
+    tdht.spawn(nDHTs, {
+      randomWalk: {
+        enabled: false
+      }
+    }, (err, dhts) => {
       expect(err).to.not.exist()
 
       series([

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -230,7 +230,11 @@ describe('KadDHT', () => {
     sw.transport.add('tcp', new TCP())
     sw.connection.addStreamMuxer(Mplex)
     sw.connection.reuse()
-    const dht = new KadDHT(sw, { enabledDiscovery: false })
+    const dht = new KadDHT(sw, {
+      randomWalk: {
+        enabled: false
+      }
+    })
 
     series([
       (cb) => dht.start(cb),
@@ -246,7 +250,11 @@ describe('KadDHT', () => {
     sw.transport.add('tcp', new TCP())
     sw.connection.addStreamMuxer(Mplex)
     sw.connection.reuse()
-    const dht = new KadDHT(sw, { enabledDiscovery: false })
+    const dht = new KadDHT(sw, {
+      randomWalk: {
+        enabled: false
+      }
+    })
 
     series([
       (cb) => dht.stop(cb)


### PR DESCRIPTION
resolves https://github.com/libp2p/js-libp2p-kad-dht/issues/100

This adds support for `delay` in the random walk config. This allows random walk to be run more quickly after startup, while maintaining a longer interval.

I ran this against js-ipfs master with a randomWalk config (all options aside from enabled are default):
```js
randomWalk: {
  enabled: true,
  interval: 300e3,
  delay: 10e3,
  timeout: 10e3
}
```

With an idle node, I had 100+ connected peers in under a minute. The connected peers eventually stabilized around the max peers of ~300.

**logging**: I also updated the randomConfig logging to make it easier to target for debugging. Instead of `DEBUG=libp2p:dht` and sifting through the logs, you can now have `DEBUG=libp2p:dht:random-walk*` and follow only random walk logs, and error logs.

**Note**: libp2p fix https://github.com/libp2p/js-libp2p/pull/359 will need to be released before `delay` can be configured by js-ipfs or other projects.