### PR TITLE
fix: random walk

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-kad-dht",
   "dependencies": {
+    "abort-controller": "^3.0.0",
     "async": "^2.6.2",
     "base32.js": "~0.1.0",
     "chai-checkmark": "^1.0.1",

--- a/src/constants.js
+++ b/src/constants.js
@@ -44,6 +44,6 @@ exports.defaultRandomWalk = {
   enabled: true,
   queriesPerPeriod: 1,
   interval: 5 * minute,
-  timeout: 10 * second,
+  timeout: 30 * second,
   delay: 10 * second
 }

--- a/src/index.js
+++ b/src/index.js
@@ -580,7 +580,7 @@ class KadDHT extends EventEmitter {
    * @param {PeerId} id
    * @param {Object} options - findPeer options
    * @param {number} options.timeout - how long the query should maximally run, in milliseconds (default: 60000)
-   * @param {EventEmitter} options.signal - an `AbortController` signal
+   * @param {AbortControllerSignal} options.signal - an `AbortController` signal
    * @param {function(Error, PeerInfo)} callback
    * @returns {void}
    */

--- a/src/index.js
+++ b/src/index.js
@@ -580,7 +580,6 @@ class KadDHT extends EventEmitter {
    * @param {PeerId} id
    * @param {Object} options - findPeer options
    * @param {number} options.timeout - how long the query should maximally run, in milliseconds (default: 60000)
-   * @param {AbortControllerSignal} options.signal - an `AbortController` signal
    * @param {function(Error, PeerInfo)} callback
    * @returns {void}
    */

--- a/src/index.js
+++ b/src/index.js
@@ -173,11 +173,10 @@ class KadDHT extends EventEmitter {
    */
   stop (callback) {
     this._running = false
-    this.randomWalk.stop(() => { // guarantee that random walk is stopped if it was started
-      this.providers.stop()
-      this.network.stop(callback)
-    })
+    this.randomWalk.stop()
+    this.providers.stop()
     this._queryManager.stop()
+    this.network.stop(callback)
   }
 
   /**
@@ -581,6 +580,7 @@ class KadDHT extends EventEmitter {
    * @param {PeerId} id
    * @param {Object} options - findPeer options
    * @param {number} options.timeout - how long the query should maximally run, in milliseconds (default: 60000)
+   * @param {EventEmitter} options.signal - an `AbortController` signal
    * @param {function(Error, PeerInfo)} callback
    * @returns {void}
    */

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ class KadDHT extends EventEmitter {
    * @property {boolean} enabled discovery enabled (default: true)
    * @property {number} queriesPerPeriod how many queries to run per period (default: 1)
    * @property {number} interval how often to run the the random-walk process, in milliseconds (default: 300000)
-   * @property {number} timeout how long to wait for the the random-walk query to run, in milliseconds (default: 10000)
+   * @property {number} timeout how long to wait for the the random-walk query to run, in milliseconds (default: 30000)
    * @property {number} delay how long to wait before starting the first random walk, in milliseconds (default: 10000)
    */
 

--- a/src/random-walk.js
+++ b/src/random-walk.js
@@ -68,6 +68,8 @@ class RandomWalk {
    * Run function `walk` on every `interval` ms
    * @param {function(callback)} walk The function to execute on `interval`
    * @param {number} interval The interval to run on in ms
+   *
+   * @private
    */
   _runPeriodically (walk, interval) {
     this._timeoutId = setTimeout(() => {
@@ -128,9 +130,17 @@ class RandomWalk {
   /**
    * The query run during a random walk request.
    *
+   * TODO: While query currently supports an abort controller, it is not
+   * yet supported by `DHT.findPeer`. Once https://github.com/libp2p/js-libp2p-kad-dht/pull/82
+   * is complete, and AbortController support has been added to the
+   * DHT query functions, the abort here will just work, provided the
+   * functions support `options.signal`. Once done, this todo should be
+   * removed.
+   *
    * @param {PeerId} id
    * @param {object} options
    * @param {number} options.timeout
+   * @param {AbortControllerSignal} options.signal
    * @param {function(Error)} callback
    * @returns {void}
    *

--- a/src/random-walk.js
+++ b/src/random-walk.js
@@ -73,8 +73,6 @@ class RandomWalk {
    */
   _runPeriodically (walk, interval) {
     this._timeoutId = setTimeout(() => {
-      this._timeoutId = null
-
       walk((nextInterval) => {
         // Schedule next
         this._runPeriodically(walk, nextInterval)

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -580,11 +580,7 @@ describe('KadDHT', () => {
     const tdht = new TestDHT()
 
     // random walk disabled for a manual usage
-    tdht.spawn(nDHTs, {
-      randomWalk: {
-        enabled: false
-      }
-    }, (err, dhts) => {
+    tdht.spawn(nDHTs, (err, dhts) => {
       expect(err).to.not.exist()
 
       series([

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -574,7 +574,7 @@ describe('KadDHT', () => {
   })
 
   it('random-walk', function (done) {
-    this.timeout(10 * 1000)
+    this.timeout(20 * 1000)
 
     const nDHTs = 20
     const tdht = new TestDHT()

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -73,7 +73,7 @@ function connect (a, b, callback) {
 
 function bootstrap (dhts) {
   dhts.forEach((dht) => {
-    dht.randomWalk._walk(1, 1000, () => {})
+    dht.randomWalk._walk(1, 10000, () => {})
   })
 }
 

--- a/test/random-walk.spec.js
+++ b/test/random-walk.spec.js
@@ -1,0 +1,215 @@
+/* eslint-env mocha */
+'use strict'
+
+const chai = require('chai')
+chai.use(require('dirty-chai'))
+chai.use(require('chai-checkmark'))
+const expect = chai.expect
+const sinon = require('sinon')
+const RandomWalk = require('../src/random-walk')
+const { defaultRandomWalk } = require('../src/constants')
+const { AssertionError } = require('assert')
+
+describe('Random Walk', () => {
+  let mockDHT = {
+    peerInfo: {
+      id: {
+        toB58String: () => 'QmRLoXS3E73psYaUsma1VSbboTa2J8Z9kso1tpiGLk9WQ4'
+      }
+    },
+    findPeer: () => {}
+  }
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  describe('configuration', () => {
+    it('should use require a dht', () => {
+      expect(() => new RandomWalk()).to.throw(AssertionError)
+    })
+
+    it('should use defaults', () => {
+      const randomWalk = new RandomWalk(mockDHT)
+      expect(randomWalk._options).to.eql(defaultRandomWalk)
+    })
+
+    it('should be able to set options', () => {
+      const options = {
+        enabled: false,
+        queriesPerPeriod: 2,
+        interval: 300e3,
+        timeout: 30e3,
+        delay: 1e3
+      }
+
+      const randomWalk = new RandomWalk(mockDHT, options)
+      expect(randomWalk._options).to.eql(options)
+    })
+  })
+
+  describe('walk', () => {
+    let randomWalk
+    before(() => {
+      randomWalk = new RandomWalk(mockDHT)
+    })
+
+    it('should be able to specify the number of queries', (done) => {
+      const queries = 5
+      sinon.stub(randomWalk, '_query').callsArgWith(2, null)
+      randomWalk._walk(queries, 1e3, (err) => {
+        expect(err).to.not.exist()
+        expect(randomWalk._query.callCount).to.eql(queries)
+        done()
+      })
+    })
+
+    it('should stop walking if a query errors', (done) => {
+      const queries = 5
+      const error = new Error('ERR_BOOM')
+      const _queryStub = sinon.stub(randomWalk, '_query')
+      _queryStub.onCall(2).callsArgWith(2, error)
+      _queryStub.callsArgWith(2, null)
+
+      randomWalk._walk(queries, 1e3, (err) => {
+        expect(err).to.eql(error)
+        // 2 successes and error on the 3rd
+        expect(randomWalk._query.callCount).to.eql(3)
+        done()
+      })
+    })
+
+    it('should ignore timeout errors and keep walking', (done) => {
+      const queries = 5
+      const _queryStub = sinon.stub(randomWalk, '_query')
+      _queryStub.onCall(2).callsArgWith(2, {
+        code: 'ETIMEDOUT'
+      })
+      _queryStub.callsArgWith(2, null)
+
+      randomWalk._walk(queries, 1e3, (err) => {
+        expect(err).to.not.exist()
+        expect(randomWalk._query.callCount).to.eql(queries)
+        done()
+      })
+    })
+
+    it('should pass its timeout to the find peer query', (done) => {
+      sinon.stub(randomWalk._kadDHT, 'findPeer').callsArgWith(2, { code: 'ERR_NOT_FOUND' })
+
+      randomWalk._walk(1, 111, (err) => {
+        const mockCalls = randomWalk._kadDHT.findPeer.getCalls()
+        expect(err).to.not.exist()
+        expect(mockCalls).to.have.length(1)
+        expect(mockCalls[0].args[1]).to.include({
+          timeout: 111
+        })
+        done()
+      })
+    })
+
+    it('should error if the random id peer is found', (done) => {
+      const queries = 5
+      const findPeerStub = sinon.stub(randomWalk._kadDHT, 'findPeer').callsArgWith(2, { code: 'ERR_NOT_FOUND' })
+      findPeerStub.onCall(2).callsArgWith(2, null, {
+        id: 'QmB'
+      })
+
+      randomWalk._walk(queries, 1e3, (err) => {
+        expect(err).to.exist()
+        expect(findPeerStub.callCount).to.eql(3)
+        done()
+      })
+    })
+
+    it('should error if random id generation errors', (done) => {
+      const error = new Error('ERR_BOOM')
+      sinon.stub(randomWalk, '_randomPeerId').callsArgWith(0, error)
+      randomWalk._walk(1, 1e3, (err) => {
+        expect(err).to.eql(error)
+        done()
+      })
+    })
+  })
+
+  describe('start', () => {
+    it('should not start if it is running', () => {
+      const randomWalk = new RandomWalk(mockDHT, {
+        enabled: true,
+        delay: 0,
+        interval: 100
+      })
+      randomWalk._running = true
+      randomWalk.start()
+      expect(randomWalk._runningHandle).to.not.exist()
+    })
+
+    it('should not start if it is not enabled', () => {
+      const randomWalk = new RandomWalk(mockDHT, {
+        enabled: false
+      })
+      randomWalk._running = true
+      randomWalk.start()
+      expect(randomWalk._runningHandle).to.not.exist()
+    })
+
+    it('should start if not running and enabled', (done) => {
+      const options = {
+        enabled: true,
+        delay: 0,
+        timeout: 3e3,
+        queriesPerPeriod: 1
+      }
+      const randomWalk = new RandomWalk(mockDHT, options)
+      sinon.stub(randomWalk, '_walk').callsFake((queries, timeout) => {
+        expect(queries).to.eql(options.queriesPerPeriod)
+        expect(timeout).to.eql(options.timeout)
+        done()
+      })
+      randomWalk.start()
+    })
+  })
+
+  describe('stop', () => {
+    it('should not throw if already stopped', () => {
+      const randomWalk = new RandomWalk(mockDHT, {
+        enabled: true,
+        delay: 0,
+        interval: 100
+      })
+
+      expect(() => randomWalk.stop()).to.not.throw()
+    })
+
+    it('should cancel the timer if the walk is not active', () => {
+      const randomWalk = new RandomWalk(mockDHT, {
+        enabled: true,
+        delay: 100e3,
+        interval: 100e3
+      })
+      randomWalk.start()
+      expect(randomWalk._runningHandle._timeoutId).to.exist()
+      randomWalk.stop()
+      expect(randomWalk._runningHandle).to.not.exist()
+    })
+
+    it('should cancel the walk if already running', (done) => {
+      const randomWalk = new RandomWalk(mockDHT, {
+        enabled: true,
+        delay: 0,
+        timeout: 100e3,
+        interval: 100e3
+      })
+      sinon.stub(randomWalk._kadDHT, 'findPeer').callsFake((id, options) => {
+        options.signal.addEventListener('abort', () => {
+          expect(randomWalk._runningHandle).to.not.exist()
+          options.signal.removeEventListener('abort')
+          done()
+        })
+        randomWalk.stop()
+      })
+
+      randomWalk.start()
+    })
+  })
+})

--- a/test/random-walk.spec.js
+++ b/test/random-walk.spec.js
@@ -139,18 +139,21 @@ describe('Random Walk', () => {
         delay: 0,
         interval: 100
       })
+      sinon.spy(randomWalk, '_runPeriodically')
 
-      sinon.stub(randomWalk, '_runPeriodically')
+      sinon.stub(randomWalk, '_walk').callsFake(() => {
+        // Try to start again
+        randomWalk.start()
 
-      randomWalk.start()
-      randomWalk.start()
-
-      // Wait a tick
-      setTimeout(() => {
-        expect(randomWalk._runPeriodically.callCount).to.eql(1)
-        randomWalk.stop()
-        done()
+        // Wait a tick to allow the 0ms delay to trigger
+        setTimeout(() => {
+          expect(randomWalk._runPeriodically.callCount).to.eql(1)
+          randomWalk.stop()
+          done()
+        })
       })
+
+      randomWalk.start()
     })
 
     it('should not start if it is not enabled', (done) => {

--- a/test/utils/test-dht.js
+++ b/test/utils/test-dht.js
@@ -36,6 +36,14 @@ class TestDHT {
       options = {}
     }
 
+    // Disable random walk by default for more controlled testing
+    options = {
+      randomWalk: {
+        enabled: false
+      },
+      ...options
+    }
+
     createPeerInfo(1, (err, peers) => {
       if (err) { return callback(err) }
 


### PR DESCRIPTION
Random Walk had some bugs, this fixes them: 
* If you ever specified more than 1 query, it would never run them. (You really shouldn;t need more than 1, but still not a good bug)
* We timed out the walk, but `findPeer` wasn't given the walks timeout. So if you specified 10seconds as your walk timeout, the `findPeer` logic would keep running until its default timeout kicked in (60 seconds)

I added a suite of tests just for RandomWalk to test the failures I was seeing.

This also adds support for AbortController in random walk and passes it to findPeer, **however**, findPeer currently isn't listening to the abort signal so it won't actually stop the query. My thought is to wait until we finish #82 and then add the abort logic to all of the query methods. Once we do, random walk will immediately benefit because it already passes the signal in. @dirkmc @vasco-santos let me know what you think, and I can update accordingly. 