### PR TITLE
chore: update cids dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "async": "^2.6.2",
     "base32.js": "~0.1.0",
     "chai-checkmark": "^1.0.1",
-    "cids": "~0.6.0",
+    "cids": "~0.7.0",
     "debug": "^4.1.1",
     "err-code": "^1.1.2",
     "hashlru": "^2.3.0",


### PR DESCRIPTION
BREAKING CHANGE: v1 CIDs are now encoded in base32 when stringified.

https://github.com/ipfs/js-ipfs/issues/1995