### PR TITLE
refactor(async): Query

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const timeout = require('async/timeout')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
 const crypto = require('libp2p-crypto')
+const promiseToCallback = require('promise-to-callback')
 
 const errcode = require('err-code')
 
@@ -376,7 +377,7 @@ class KadDHT extends EventEmitter {
 
           // run our query
           timeout((_cb) => {
-            query.run(rtp, _cb)
+            promiseToCallback(query.runAsync(rtp))(_cb)
           }, options.timeout)((err, res) => {
             query.stop()
             cb(err, res)
@@ -438,7 +439,7 @@ class KadDHT extends EventEmitter {
         }
       })
 
-      q.run(tablePeers, (err, res) => {
+      promiseToCallback(q.runAsync(tablePeers))((err, res) => {
         if (err) {
           return callback(err)
         }
@@ -673,7 +674,7 @@ class KadDHT extends EventEmitter {
           })
 
           timeout((_cb) => {
-            query.run(peers, _cb)
+            promiseToCallback(query.runAsync(peers))(_cb)
           }, options.timeout)((err, res) => {
             query.stop()
             cb(err, res)

--- a/src/index.js
+++ b/src/index.js
@@ -377,7 +377,7 @@ class KadDHT extends EventEmitter {
 
           // run our query
           timeout((_cb) => {
-            promiseToCallback(query.runAsync(rtp))(_cb)
+            promiseToCallback(query.run(rtp))(_cb)
           }, options.timeout)((err, res) => {
             query.stop()
             cb(err, res)
@@ -439,7 +439,7 @@ class KadDHT extends EventEmitter {
         }
       })
 
-      promiseToCallback(q.runAsync(tablePeers))((err, res) => {
+      promiseToCallback(q.run(tablePeers))((err, res) => {
         if (err) {
           return callback(err)
         }
@@ -674,7 +674,7 @@ class KadDHT extends EventEmitter {
           })
 
           timeout((_cb) => {
-            promiseToCallback(query.runAsync(peers))(_cb)
+            promiseToCallback(query.run(peers))(_cb)
           }, options.timeout)((err, res) => {
             query.stop()
             cb(err, res)

--- a/src/peer-queue.js
+++ b/src/peer-queue.js
@@ -4,7 +4,6 @@ const Heap = require('heap')
 const distance = require('xor-distance')
 const debug = require('debug')
 const promisify = require('promisify-es6')
-const promiseToCallback = require('promise-to-callback')
 
 const utils = require('./utils')
 

--- a/src/peer-queue.js
+++ b/src/peer-queue.js
@@ -66,10 +66,10 @@ class PeerQueue {
    * @returns {void}
    */
   enqueue (id, callback) {
-    promiseToCallback(this._enqueueAsync(id))(callback)
+    promiseToCallback(this.enqueueAsync(id))(callback)
   }
 
-  async _enqueueAsync (id) {
+  async enqueueAsync (id) {
     log('enqueue %s', id.toB58String())
     const key = await promisify(cb => utils.convertPeerId(id, cb))()
 

--- a/src/peer-queue.js
+++ b/src/peer-queue.js
@@ -23,10 +23,10 @@ class PeerQueue {
    * @returns {void}
    */
   static fromPeerId (id, callback) {
-    promiseToCallback(this._fromPeerIdAsync(id))(callback)
+    promiseToCallback(this.fromPeerIdAsync(id))(callback)
   }
 
-  static async _fromPeerIdAsync (id) {
+  static async fromPeerIdAsync (id) {
     const key = await promisify(cb => utils.convertPeerId(id, cb))()
     return new PeerQueue(key)
   }
@@ -39,10 +39,10 @@ class PeerQueue {
    * @returns {void}
    */
   static fromKey (keyBuffer, callback) {
-    promiseToCallback(this._fromKeyAsync(keyBuffer))(callback)
+    promiseToCallback(this.fromKeyAsync(keyBuffer))(callback)
   }
 
-  static async _fromKeyAsync (keyBuffer) {
+  static async fromKeyAsync (keyBuffer) {
     const key = await promisify(cb => utils.convertBuffer(keyBuffer, cb))()
     return new PeerQueue(key)
   }

--- a/src/peer-queue.js
+++ b/src/peer-queue.js
@@ -19,14 +19,9 @@ class PeerQueue {
    * Create from a given peer id.
    *
    * @param {PeerId} id
-   * @param {function(Error, PeerQueue)} callback
-   * @returns {void}
+   * @returns {Promise<PeerQueue>}
    */
-  static fromPeerId (id, callback) {
-    promiseToCallback(this.fromPeerIdAsync(id))(callback)
-  }
-
-  static async fromPeerIdAsync (id) {
+  static async fromPeerId (id) {
     const key = await promisify(cb => utils.convertPeerId(id, cb))()
     return new PeerQueue(key)
   }
@@ -35,14 +30,9 @@ class PeerQueue {
    * Create from a given buffer.
    *
    * @param {Buffer} keyBuffer
-   * @param {function(Error, PeerQueue)} callback
-   * @returns {void}
+   * @returns {Promise<PeerQueue>}
    */
-  static fromKey (keyBuffer, callback) {
-    promiseToCallback(this.fromKeyAsync(keyBuffer))(callback)
-  }
-
-  static async fromKeyAsync (keyBuffer) {
+  static async fromKey (keyBuffer) {
     const key = await promisify(cb => utils.convertBuffer(keyBuffer, cb))()
     return new PeerQueue(key)
   }
@@ -62,14 +52,9 @@ class PeerQueue {
    * Add a new PeerId to the queue.
    *
    * @param {PeerId} id
-   * @param {function(Error)} callback
-   * @returns {void}
+   * @returns {Promise}
    */
-  enqueue (id, callback) {
-    promiseToCallback(this.enqueueAsync(id))(callback)
-  }
-
-  async enqueueAsync (id) {
+  async enqueue (id) {
     log('enqueue %s', id.toB58String())
     const key = await promisify(cb => utils.convertPeerId(id, cb))()
 

--- a/src/private.js
+++ b/src/private.js
@@ -571,7 +571,9 @@ module.exports = (dht) => ({
     const peers = dht.routingTable.closestPeers(key.buffer, dht.kBucketSize)
 
     try {
-      await promisify(callback => timeout((cb) => query.run(peers, cb), providerTimeout)(callback))()
+      await promisify(callback => timeout((cb) => {
+        promiseToCallback(query.runAsync(peers))(cb)
+      }, providerTimeout)(callback))()
     } catch (err) {
       if (err.code !== 'ETIMEDOUT' || out.length === 0) {
         throw err

--- a/src/private.js
+++ b/src/private.js
@@ -572,7 +572,7 @@ module.exports = (dht) => ({
 
     try {
       await promisify(callback => timeout((cb) => {
-        promiseToCallback(query.runAsync(peers))(cb)
+        promiseToCallback(query.run(peers))(cb)
       }, providerTimeout)(callback))()
     } catch (err) {
       if (err.code !== 'ETIMEDOUT' || out.length === 0) {

--- a/src/query/index.js
+++ b/src/query/index.js
@@ -55,10 +55,10 @@ class Query {
    * @returns {void}
    */
   run (peers, callback) {
-    promiseToCallback(this._runAsync(peers))(callback)
+    promiseToCallback(this.runAsync(peers))(callback)
   }
 
-  async _runAsync (peers) {
+  async runAsync (peers) {
     if (!this.dht._queryManager.running) {
       this._log.error('Attempt to run query after shutdown')
       return { finalSet: new Set(), paths: [] }
@@ -74,7 +74,7 @@ class Query {
     this._log(`query running with K=${this.dht.kBucketSize}, A=${this.dht.concurrency}, D=${Math.min(this.dht.disjointPaths, peers.length)}`)
     this._run.once('start', this._onStart)
     this._run.once('complete', this._onComplete)
-    return this._run._executeAsync(peers)
+    return this._run.executeAsync(peers)
   }
 
   /**

--- a/src/query/index.js
+++ b/src/query/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const mh = require('multihashes')
-const promisify = require('promisify-es6')
 const promiseToCallback = require('promise-to-callback')
 
 const utils = require('../utils')
@@ -75,7 +74,7 @@ class Query {
     this._log(`query running with K=${this.dht.kBucketSize}, A=${this.dht.concurrency}, D=${Math.min(this.dht.disjointPaths, peers.length)}`)
     this._run.once('start', this._onStart)
     this._run.once('complete', this._onComplete)
-    return promisify(cb => this._run.execute(peers, cb))()
+    return this._run._executeAsync(peers)
   }
 
   /**

--- a/src/query/index.js
+++ b/src/query/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const mh = require('multihashes')
-const promiseToCallback = require('promise-to-callback')
 
 const utils = require('../utils')
 const Run = require('./run')

--- a/src/query/index.js
+++ b/src/query/index.js
@@ -74,7 +74,7 @@ class Query {
     this._log(`query running with K=${this.dht.kBucketSize}, A=${this.dht.concurrency}, D=${Math.min(this.dht.disjointPaths, peers.length)}`)
     this._run.once('start', this._onStart)
     this._run.once('complete', this._onComplete)
-    return this._run.executeAsync(peers)
+    return this._run.execute(peers)
   }
 
   /**

--- a/src/query/index.js
+++ b/src/query/index.js
@@ -51,14 +51,9 @@ class Query {
    * Run this query, start with the given list of peers first.
    *
    * @param {Array<PeerId>} peers
-   * @param {function(Error, Object)} callback
-   * @returns {void}
+   * @returns {Promise}
    */
-  run (peers, callback) {
-    promiseToCallback(this.runAsync(peers))(callback)
-  }
-
-  async runAsync (peers) {
+  async run (peers) {
     if (!this.dht._queryManager.running) {
       this._log.error('Attempt to run query after shutdown')
       return { finalSet: new Set(), paths: [] }

--- a/src/query/path.js
+++ b/src/query/path.js
@@ -57,7 +57,7 @@ class Path {
 
   async executeAsync () {
     // Create a queue of peers ordered by distance from the key
-    const queue = await PeerQueue.fromKeyAsync(this.run.query.key)
+    const queue = await PeerQueue.fromKey(this.run.query.key)
     // Add initial peers to the queue
     this.peersToQuery = queue
     await Promise.all(this.initialPeers.map(peer => this.addPeerToQueryAsync(peer)))
@@ -88,7 +88,7 @@ class Path {
       return
     }
 
-    await this.peersToQuery.enqueueAsync(peer)
+    await this.peersToQuery.enqueue(peer)
   }
 }
 

--- a/src/query/path.js
+++ b/src/query/path.js
@@ -2,7 +2,6 @@
 
 const timeout = require('async/timeout')
 const promisify = require('promisify-es6')
-const promiseToCallback = require('promise-to-callback')
 const PeerQueue = require('../peer-queue')
 
 // TODO: Temporary until parallel dial in Switch have a proper
@@ -49,18 +48,15 @@ class Path {
   /**
    * Execute the path.
    *
-   * @param {function(Error)} callback
+   * @returns {Promise}
+   * 
    */
-  execute (callback) {
-    promiseToCallback(this.executeAsync())(callback)
-  }
-
-  async executeAsync () {
+  async execute () {
     // Create a queue of peers ordered by distance from the key
     const queue = await PeerQueue.fromKey(this.run.query.key)
     // Add initial peers to the queue
     this.peersToQuery = queue
-    await Promise.all(this.initialPeers.map(peer => this.addPeerToQueryAsync(peer)))
+    await Promise.all(this.initialPeers.map(peer => this.addPeerToQuery(peer)))
     await this.run.workerQueueAsync(this)
   }
 
@@ -68,15 +64,9 @@ class Path {
    * Add a peer to the peers to be queried.
    *
    * @param {PeerId} peer
-   * @param {function(Error)} callback
-   * @returns {void}
-   * @private
+   * @returns {Promise<void>}
    */
-  addPeerToQuery (peer, callback) {
-    promiseToCallback(this.addPeerToQueryAsync(peer))(callback)
-  }
-
-  async addPeerToQueryAsync (peer) {
+  async addPeerToQuery (peer) {
     // Don't add self
     if (this.run.query.dht._isSelf(peer)) {
       return

--- a/src/query/path.js
+++ b/src/query/path.js
@@ -49,7 +49,7 @@ class Path {
    * Execute the path.
    *
    * @returns {Promise}
-   * 
+   *
    */
   async execute () {
     // Create a queue of peers ordered by distance from the key

--- a/src/query/path.js
+++ b/src/query/path.js
@@ -88,7 +88,7 @@ class Path {
       return
     }
 
-    await this.peersToQuery._enqueueAsync(peer)
+    await this.peersToQuery.enqueueAsync(peer)
   }
 }
 

--- a/src/query/path.js
+++ b/src/query/path.js
@@ -57,7 +57,7 @@ class Path {
     // Add initial peers to the queue
     this.peersToQuery = queue
     await Promise.all(this.initialPeers.map(peer => this.addPeerToQuery(peer)))
-    await this.run.workerQueueAsync(this)
+    await this.run.workerQueue(this)
   }
 
   /**

--- a/src/query/path.js
+++ b/src/query/path.js
@@ -52,16 +52,16 @@ class Path {
    * @param {function(Error)} callback
    */
   execute (callback) {
-    promiseToCallback(this._executeAsync())(callback)
+    promiseToCallback(this.executeAsync())(callback)
   }
 
-  async _executeAsync () {
+  async executeAsync () {
     // Create a queue of peers ordered by distance from the key
-    const queue = await PeerQueue._fromKeyAsync(this.run.query.key)
+    const queue = await PeerQueue.fromKeyAsync(this.run.query.key)
     // Add initial peers to the queue
     this.peersToQuery = queue
-    await Promise.all(this.initialPeers.map(peer => this._addPeerToQueryAsync(peer)))
-    await this.run._workerQueueAsync(this)
+    await Promise.all(this.initialPeers.map(peer => this.addPeerToQueryAsync(peer)))
+    await this.run.workerQueueAsync(this)
   }
 
   /**
@@ -73,10 +73,10 @@ class Path {
    * @private
    */
   addPeerToQuery (peer, callback) {
-    promiseToCallback(this._addPeerToQueryAsync(peer))(callback)
+    promiseToCallback(this.addPeerToQueryAsync(peer))(callback)
   }
 
-  async _addPeerToQueryAsync (peer) {
+  async addPeerToQueryAsync (peer) {
     // Don't add self
     if (this.run.query.dht._isSelf(peer)) {
       return

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -136,8 +136,8 @@ class Run extends EventEmitter {
   }
 
   async _workerQueueAsync (path) {
-    await promisify(cb => this.init(cb))()
-    return promisify(cb => this.startWorker(path, cb))()
+    await this._initAsync()
+    await this._startWorkerAsync(path)
   }
 
   /**

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -108,7 +108,7 @@ class Run extends EventEmitter {
 
     this.emit('start')
     try {
-      await Promise.all(paths.map(path => path.executeAsync()))
+      await Promise.all(paths.map(path => path.execute()))
     } finally {
       // Ensure all workers are stopped
       this.stop()

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -109,7 +109,7 @@ class Run extends EventEmitter {
 
     this.emit('start')
     try {
-      await promisify(callback => each(paths, (path, cb) => path.execute(cb), callback))()
+      await Promise.all(paths.map(path => path._executeAsync()))
     } finally {
       // Ensure all workers are stopped
       this.stop()

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -3,7 +3,6 @@
 const PeerDistanceList = require('../peer-distance-list')
 const EventEmitter = require('events')
 const promisify = require('promisify-es6')
-const promiseToCallback = require('promise-to-callback')
 
 const Path = require('./path')
 const WorkerQueue = require('./workerQueue')
@@ -132,7 +131,7 @@ class Run extends EventEmitter {
    * Create and start a worker queue for a particular path.
    *
    * @param {Path} path
-   * @returns {Promise<void>}   
+   * @returns {Promise<void>}
    */
   async startWorker (path) {
     const worker = new WorkerQueue(this.query.dht, this, path, this.query._log)

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -137,7 +137,7 @@ class Run extends EventEmitter {
   async startWorker (path) {
     const worker = new WorkerQueue(this.query.dht, this, path, this.query._log)
     this.workers.push(worker)
-    await worker.executeAsync()
+    await worker.execute()
   }
 
   /**

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -56,10 +56,10 @@ class Run extends EventEmitter {
    * @param {function(Error, Object)} callback
    */
   execute (peers, callback) {
-    promiseToCallback(this._executeAsync(peers))(callback)
+    promiseToCallback(this.executeAsync(peers))(callback)
   }
 
-  async _executeAsync (peers) {
+  async executeAsync (peers) {
     const paths = [] // array of states per disjoint path
 
     // Create disjoint paths
@@ -74,7 +74,7 @@ class Run extends EventEmitter {
     })
 
     // Execute the query along each disjoint path
-    await this._executePathsAsync(paths)
+    await this.executePathsAsync(paths)
 
     const res = {
       // The closest K peers we were able to query successfully
@@ -100,15 +100,15 @@ class Run extends EventEmitter {
    * @param {function(Error)} callback
    */
   executePaths (paths, callback) {
-    promiseToCallback(this._executePathsAsync(paths))(callback)
+    promiseToCallback(this.executePathsAsync(paths))(callback)
   }
 
-  async _executePathsAsync (paths) {
+  async executePathsAsync (paths) {
     this.running = true
 
     this.emit('start')
     try {
-      await Promise.all(paths.map(path => path._executeAsync()))
+      await Promise.all(paths.map(path => path.executeAsync()))
     } finally {
       // Ensure all workers are stopped
       this.stop()
@@ -131,12 +131,12 @@ class Run extends EventEmitter {
    * @param {function(Error)} callback
    */
   workerQueue (path, callback) {
-    promiseToCallback(this._workerQueueAsync(path))(callback)
+    promiseToCallback(this.workerQueueAsync(path))(callback)
   }
 
-  async _workerQueueAsync (path) {
-    await this._initAsync()
-    await this._startWorkerAsync(path)
+  async workerQueueAsync (path) {
+    await this.initAsync()
+    await this.startWorkerAsync(path)
   }
 
   /**
@@ -146,10 +146,10 @@ class Run extends EventEmitter {
    * @param {function(Error)} callback
    */
   startWorker (path, callback) {
-    promiseToCallback(this._startWorkerAsync(path))(callback)
+    promiseToCallback(this.startWorkerAsync(path))(callback)
   }
 
-  async _startWorkerAsync (path) {
+  async startWorkerAsync (path) {
     const worker = new WorkerQueue(this.query.dht, this, path, this.query._log)
     this.workers.push(worker)
     return promisify(cb => worker.execute(cb))()
@@ -163,10 +163,10 @@ class Run extends EventEmitter {
    * @returns {void}
    */
   init (callback) {
-    promiseToCallback(this._initAsync())(callback)
+    promiseToCallback(this.initAsync())(callback)
   }
 
-  async _initAsync () {
+  async initAsync () {
     if (this.peersQueried) {
       return
     }
@@ -198,10 +198,10 @@ class Run extends EventEmitter {
    * @returns {void}
    */
   continueQuerying (worker, callback) {
-    promiseToCallback(this._continueQueryingAsync(worker))(callback)
+    promiseToCallback(this.continueQueryingAsync(worker))(callback)
   }
 
-  async _continueQueryingAsync (worker) {
+  async continueQueryingAsync (worker) {
     // If we haven't queried K peers yet, keep going
     if (this.peersQueried.length < this.peersQueried.capacity) {
       return true

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -3,6 +3,9 @@
 const PeerDistanceList = require('../peer-distance-list')
 const EventEmitter = require('events')
 const each = require('async/each')
+const promisify = require('promisify-es6')
+const promiseToCallback = require('promise-to-callback')
+
 const Path = require('./path')
 const WorkerQueue = require('./workerQueue')
 const utils = require('../utils')
@@ -54,6 +57,10 @@ class Run extends EventEmitter {
    * @param {function(Error, Object)} callback
    */
   execute (peers, callback) {
+    promiseToCallback(this._executeAsync(peers))(callback)
+  }
+
+  async _executeAsync (peers) {
     const paths = [] // array of states per disjoint path
 
     // Create disjoint paths
@@ -68,27 +75,23 @@ class Run extends EventEmitter {
     })
 
     // Execute the query along each disjoint path
-    this.executePaths(paths, (err) => {
-      if (err) {
-        return callback(err)
-      }
+    await this._executePathsAsync(paths)
 
-      const res = {
-        // The closest K peers we were able to query successfully
-        finalSet: new Set(this.peersQueried.peers),
-        paths: []
-      }
+    const res = {
+      // The closest K peers we were able to query successfully
+      finalSet: new Set(this.peersQueried.peers),
+      paths: []
+    }
 
-      // Collect the results from each completed path
-      for (const path of paths) {
-        if (path.res && (path.res.pathComplete || path.res.queryComplete)) {
-          path.res.success = true
-          res.paths.push(path.res)
-        }
+    // Collect the results from each completed path
+    for (const path of paths) {
+      if (path.res && (path.res.pathComplete || path.res.queryComplete)) {
+        path.res.success = true
+        res.paths.push(path.res)
       }
+    }
 
-      callback(err, res)
-    })
+    return res
   }
 
   /**
@@ -98,28 +101,29 @@ class Run extends EventEmitter {
    * @param {function(Error)} callback
    */
   executePaths (paths, callback) {
+    promiseToCallback(this._executePathsAsync(paths))(callback)
+  }
+
+  async _executePathsAsync (paths) {
     this.running = true
 
     this.emit('start')
-    each(paths, (path, cb) => path.execute(cb), (err) => {
+    try {
+      await promisify(callback => each(paths, (path, cb) => path.execute(cb), callback))()
+    } catch (err) {
+      throw err
+    } finally {
       // Ensure all workers are stopped
       this.stop()
-
       // Completed the Run
       this.emit('complete')
+    }
 
-      if (err) {
-        return callback(err)
-      }
-
-      // If all queries errored out, something is seriously wrong, so callback
-      // with an error
-      if (this.errors.length === this.peersSeen.size) {
-        return callback(this.errors[0])
-      }
-
-      callback()
-    })
+    // If all queries errored out, something is seriously wrong, so callback
+    // with an error
+    if (this.errors.length === this.peersSeen.size) {
+      throw this.errors[0]
+    }
   }
 
   /**
@@ -130,7 +134,12 @@ class Run extends EventEmitter {
    * @param {function(Error)} callback
    */
   workerQueue (path, callback) {
-    this.init(() => this.startWorker(path, callback))
+    promiseToCallback(this._workerQueueAsync(path))(callback)
+  }
+
+  async _workerQueueAsync (path) {
+    await promisify(cb => this.init(cb))()
+    return promisify(cb => this.startWorker(path, cb))()
   }
 
   /**
@@ -140,9 +149,13 @@ class Run extends EventEmitter {
    * @param {function(Error)} callback
    */
   startWorker (path, callback) {
+    promiseToCallback(this._startWorkerAsync(path))(callback)
+  }
+
+  async _startWorkerAsync (path) {
     const worker = new WorkerQueue(this.query.dht, this, path, this.query._log)
     this.workers.push(worker)
-    worker.execute(callback)
+    return promisify(cb => worker.execute(cb))()
   }
 
   /**
@@ -153,28 +166,29 @@ class Run extends EventEmitter {
    * @returns {void}
    */
   init (callback) {
-    if (this.peersQueried) {
-      return callback()
-    }
+    promiseToCallback(this._initAsync())(callback)
+  }
 
-    // We only want to initialize it once for the run, and then inform each
-    // path worker that it's ready
-    if (this.awaitingKey) {
-      this.awaitingKey.push(callback)
+  async _initAsync () {
+    if (this.peersQueried) {
       return
     }
 
-    this.awaitingKey = [callback]
+    // We only want to initialize the PeerDistanceList once for the run
+    if (this.peersQueriedPromise) {
+      await this.peersQueriedPromise
+      return
+    }
 
-    // Convert the key into a DHT key by hashing it
-    utils.convertBuffer(this.query.key, (err, dhtKey) => {
+    // This promise is temporarily stored so that others may await its completion
+    this.peersQueriedPromise = (async () => {
+      const dhtKey = await promisify(cb => utils.convertBuffer(this.query.key, cb))()
       this.peersQueried = new PeerDistanceList(dhtKey, this.query.dht.kBucketSize)
+    })()
 
-      for (const cb of this.awaitingKey) {
-        cb(err)
-      }
-      this.awaitingKey = undefined
-    })
+    // After PeerDistanceList is initialized, clean up
+    await this.peersQueriedPromise
+    delete this.peersQueriedPromise
   }
 
   /**
@@ -187,9 +201,13 @@ class Run extends EventEmitter {
    * @returns {void}
    */
   continueQuerying (worker, callback) {
+    promiseToCallback(this._continueQueryingAsync(worker))(callback)
+  }
+
+  async _continueQueryingAsync (worker) {
     // If we haven't queried K peers yet, keep going
     if (this.peersQueried.length < this.peersQueried.capacity) {
-      return callback(null, true)
+      return true
     }
 
     // Get all the peers that are currently being queried.
@@ -199,19 +217,15 @@ class Run extends EventEmitter {
 
     // Check if any of the peers that are currently being queried are closer
     // to the key than the peers we've already queried
-    this.peersQueried.anyCloser(running, (err, someCloser) => {
-      if (err) {
-        return callback(err)
-      }
+    const someCloser = await promisify(cb => this.peersQueried.anyCloser(running, cb))()
 
-      // Some are closer, the worker should keep going
-      if (someCloser) {
-        return callback(null, true)
-      }
+    // Some are closer, the worker should keep going
+    if (someCloser) {
+      return true
+    }
 
-      // None are closer, the worker can stop
-      callback(null, false)
-    })
+    // None are closer, the worker can stop
+    return false
   }
 }
 

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -110,8 +110,6 @@ class Run extends EventEmitter {
     this.emit('start')
     try {
       await promisify(callback => each(paths, (path, cb) => path.execute(cb), callback))()
-    } catch (err) {
-      throw err
     } finally {
       // Ensure all workers are stopped
       this.stop()

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -152,7 +152,7 @@ class Run extends EventEmitter {
   async startWorkerAsync (path) {
     const worker = new WorkerQueue(this.query.dht, this, path, this.query._log)
     this.workers.push(worker)
-    return promisify(cb => worker.execute(cb))()
+    await worker.executeAsync()
   }
 
   /**

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -53,7 +53,7 @@ class Run extends EventEmitter {
    * Execute the run with the given initial set of peers.
    *
    * @param {Array<PeerId>} peers
-   * @returns {Promise<void>}
+   * @returns {Promise}
    */
 
   async execute (peers) {

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -2,7 +2,6 @@
 
 const PeerDistanceList = require('../peer-distance-list')
 const EventEmitter = require('events')
-const each = require('async/each')
 const promisify = require('promisify-es6')
 const promiseToCallback = require('promise-to-callback')
 

--- a/src/query/workerQueue.js
+++ b/src/query/workerQueue.js
@@ -261,7 +261,7 @@ class WorkerQueue {
         }
         closer = this.dht.peerBook.put(closer)
         this.dht._peerDiscovered(closer)
-        await this.path.addPeerToQueryAsync(closer.id)
+        await this.path.addPeerToQuery(closer.id)
       }))
     }
   }

--- a/src/query/workerQueue.js
+++ b/src/query/workerQueue.js
@@ -32,7 +32,9 @@ class WorkerQueue {
    * @returns {Object}
    */
   setupQueue () {
-    const q = queue(this.processNext.bind(this), this.concurrency)
+    const q = queue((peer, cb) => {
+      promiseToCallback(this.processNextAsync(peer))(cb)
+    }, this.concurrency)
 
     // If there's an error, stop the worker
     q.error = (err) => {

--- a/src/query/workerQueue.js
+++ b/src/query/workerQueue.js
@@ -145,7 +145,7 @@ class WorkerQueue {
     // Check if we've queried enough peers already
     let continueQuerying, continueQueryingError
     try {
-      continueQuerying = await this.run.continueQueryingAsync(this)
+      continueQuerying = await this.run.continueQuerying(this)
     } catch (err) {
       continueQueryingError = err
     }

--- a/src/query/workerQueue.js
+++ b/src/query/workerQueue.js
@@ -1,7 +1,8 @@
 'use strict'
 
-const each = require('async/each')
 const queue = require('async/queue')
+const promisify = require('promisify-es6')
+const promiseToCallback = require('promise-to-callback')
 
 class WorkerQueue {
   /**
@@ -20,6 +21,9 @@ class WorkerQueue {
 
     this.concurrency = this.dht.concurrency
     this.queue = this.setupQueue()
+    // a container for resolve/reject functions that will be populated
+    // when execute() is called
+    this.execution = null
   }
 
   /**
@@ -68,7 +72,11 @@ class WorkerQueue {
     this.running = false
     this.queue.kill()
     this.log('worker:stop, %d workers still running', this.run.workers.filter(w => w.running).length)
-    this.callbackFn(err)
+    if (err) {
+      this.execution.reject(err)
+    } else {
+      this.execution.resolve()
+    }
   }
 
   /**
@@ -78,9 +86,18 @@ class WorkerQueue {
    * @param {function(Error)} callback
    */
   execute (callback) {
+    promiseToCallback(this._executeAsync())(callback)
+  }
+
+  async _executeAsync () {
     this.running = true
-    this.callbackFn = callback
+    // store the promise resolution functions to be resolved at end of queue
+    this.execution = {}
+    const execPromise = new Promise((resolve, reject) => Object.assign(this.execution, { resolve, reject }))
+    // start queue
     this.fill()
+    // await completion
+    await execPromise
   }
 
   /**
@@ -109,73 +126,85 @@ class WorkerQueue {
    * @returns {void}
    */
   processNext (peer, cb) {
+    promiseToCallback(this._processNextAsync(peer))(cb)
+  }
+
+  async _processNextAsync (peer) {
     if (!this.running) {
-      return cb()
+      return
     }
 
     // The paths must be disjoint, meaning that no two paths in the Query may
     // traverse the same peer
     if (this.run.peersSeen.has(peer)) {
-      return cb()
+      return
     }
 
     // Check if we've queried enough peers already
-    this.run.continueQuerying(this, (err, continueQuerying) => {
-      if (!this.running) {
-        return cb()
-      }
+    let continueQuerying, continueQueryingError
+    try {
+      continueQuerying = await this.run._continueQueryingAsync(this)
+    } catch (err) {
+      continueQueryingError = err
+    }
 
-      if (err) {
-        return cb(err)
-      }
+    // Abort and ignore any error if we're no longer running
+    if (!this.running) {
+      return
+    }
 
-      // No peer we're querying is closer stop the queue
-      // This will cause queries that may potentially result in
-      // closer nodes to be ended, but it reduces overall query time
-      if (!continueQuerying) {
-        this.stop()
-        return cb()
-      }
+    if (continueQueryingError) {
+      throw continueQueryingError
+    }
 
-      // Check if another path has queried this peer in the mean time
-      if (this.run.peersSeen.has(peer)) {
-        return cb()
-      }
-      this.run.peersSeen.add(peer)
+    // No peer we're querying is closer, stop the queue
+    // This will cause queries that may potentially result in
+    // closer nodes to be ended, but it reduces overall query time
+    if (!continueQuerying) {
+      this.stop()
+      return
+    }
 
-      // Execute the query on the next peer
-      this.log('queue:work')
-      this.execQuery(peer, (err, state) => {
-        // Ignore response after worker killed
-        if (!this.running) {
-          return cb()
-        }
+    // Check if another path has queried this peer in the mean time
+    if (this.run.peersSeen.has(peer)) {
+      return
+    }
+    this.run.peersSeen.add(peer)
 
-        this.log('queue:work:done', err, state)
-        if (err) {
-          return cb(err)
-        }
+    // Execute the query on the next peer
+    this.log('queue:work')
+    let state, execError
+    try {
+      state = await this._execQueryAsync(peer)
+    } catch (err) {
+      execError = err
+    }
 
-        // If query is complete, stop all workers.
-        // Note: run.stop() calls stop() on all the workers, which kills the
-        // queue and calls callbackFn()
-        if (state && state.queryComplete) {
-          this.log('query:complete')
-          this.run.stop()
-          return cb()
-        }
+    // Abort and ignore any error if we're no longer running
+    if (!this.running) {
+      return
+    }
 
-        // If path is complete, just stop this worker.
-        // Note: this.stop() kills the queue and calls callbackFn()
-        if (state && state.pathComplete) {
-          this.stop()
-          return cb()
-        }
+    this.log('queue:work:done', execError, state)
 
-        // Otherwise, process next peer
-        cb()
-      })
-    })
+    if (execError) {
+      throw execError
+    }
+
+    // If query is complete, stop all workers.
+    // Note: run.stop() calls stop() on all the workers, which kills the
+    // queue and resolves execution
+    if (state && state.queryComplete) {
+      this.log('query:complete')
+      this.run.stop()
+      return
+    }
+
+    // If path is complete, just stop this worker.
+    // Note: this.stop() kills the queue and resolves execution
+    if (state && state.pathComplete) {
+      this.stop()
+    }
   }
 
   /**
@@ -187,49 +216,52 @@ class WorkerQueue {
    * @private
    */
   execQuery (peer, callback) {
-    this.path.queryFunc(peer, (err, res) => {
-      // If the run has completed, bail out
-      if (!this.running) {
-        return callback()
+    promiseToCallback(this._execQueryAsync(peer))(callback)
+  }
+
+  async _execQueryAsync (peer) {
+    let res, queryError
+    try {
+      res = await this.path.queryFuncAsync(peer)
+    } catch (err) {
+      queryError = err
+    }
+
+    // Abort and ignore any error if we're no longer running
+    if (!this.running) {
+      return
+    }
+
+    if (queryError) {
+      this.run.errors.push(queryError)
+      return
+    }
+
+    // Add the peer to the closest peers we have successfully queried
+    await promisify(cb => this.run.peersQueried.add(peer, cb))()
+
+    // If the query indicates that this path or the whole query is complete
+    // set the path result and bail out
+    if (res.pathComplete || res.queryComplete) {
+      this.path.res = res
+      return {
+        pathComplete: res.pathComplete,
+        queryComplete: res.queryComplete
       }
+    }
 
-      if (err) {
-        this.run.errors.push(err)
-        return callback()
-      }
-
-      // Add the peer to the closest peers we have successfully queried
-      this.run.peersQueried.add(peer, (err) => {
-        if (err) {
-          return callback(err)
+    // If there are closer peers to query, add them to the queue
+    if (res.closerPeers && res.closerPeers.length > 0) {
+      await Promise.all(res.closerPeers.map(async (closer) => {
+        // don't add ourselves
+        if (this.dht._isSelf(closer.id)) {
+          return
         }
-
-        // If the query indicates that this path or the whole query is complete
-        // set the path result and bail out
-        if (res.pathComplete || res.queryComplete) {
-          this.path.res = res
-          return callback(null, {
-            pathComplete: res.pathComplete,
-            queryComplete: res.queryComplete
-          })
-        }
-
-        // If there are closer peers to query, add them to the queue
-        if (res.closerPeers && res.closerPeers.length > 0) {
-          return each(res.closerPeers, (closer, cb) => {
-            // don't add ourselves
-            if (this.dht._isSelf(closer.id)) {
-              return cb()
-            }
-            closer = this.dht.peerBook.put(closer)
-            this.dht._peerDiscovered(closer)
-            this.path.addPeerToQuery(closer.id, cb)
-          }, callback)
-        }
-
-        callback()
-      })
-    })
+        closer = this.dht.peerBook.put(closer)
+        this.dht._peerDiscovered(closer)
+        await this.path._addPeerToQueryAsync(closer.id)
+      }))
+    }
   }
 }
 

--- a/src/query/workerQueue.js
+++ b/src/query/workerQueue.js
@@ -33,7 +33,7 @@ class WorkerQueue {
    */
   setupQueue () {
     const q = queue((peer, cb) => {
-      promiseToCallback(this.processNextAsync(peer))(cb)
+      promiseToCallback(this.processNext(peer))(cb)
     }, this.concurrency)
 
     // If there's an error, stop the worker
@@ -85,13 +85,9 @@ class WorkerQueue {
    * Use the queue from async to keep `concurrency` amount items running
    * per path.
    *
-   * @param {function(Error)} callback
+   * @return {Promise<void>}
    */
-  execute (callback) {
-    promiseToCallback(this.executeAsync())(callback)
-  }
-
-  async executeAsync () {
+  async execute () {
     this.running = true
     // store the promise resolution functions to be resolved at end of queue
     this.execution = {}
@@ -124,14 +120,9 @@ class WorkerQueue {
    * Process the next peer in the queue
    *
    * @param {PeerId} peer
-   * @param {function(Error)} cb
-   * @returns {void}
+   * @returns {Promise<void>}
    */
-  processNext (peer, cb) {
-    promiseToCallback(this.processNextAsync(peer))(cb)
-  }
-
-  async processNextAsync (peer) {
+  async processNext (peer) {
     if (!this.running) {
       return
     }
@@ -177,7 +168,7 @@ class WorkerQueue {
     this.log('queue:work')
     let state, execError
     try {
-      state = await this.execQueryAsync(peer)
+      state = await this.execQuery(peer)
     } catch (err) {
       execError = err
     }
@@ -213,15 +204,10 @@ class WorkerQueue {
    * Execute a query on the next peer.
    *
    * @param {PeerId} peer
-   * @param {function(Error)} callback
-   * @returns {void}
+   * @returns {Promise<void>}
    * @private
    */
-  execQuery (peer, callback) {
-    promiseToCallback(this.execQueryAsync(peer))(callback)
-  }
-
-  async execQueryAsync (peer) {
+  async execQuery (peer) {
     let res, queryError
     try {
       res = await this.path.queryFuncAsync(peer)

--- a/src/query/workerQueue.js
+++ b/src/query/workerQueue.js
@@ -86,10 +86,10 @@ class WorkerQueue {
    * @param {function(Error)} callback
    */
   execute (callback) {
-    promiseToCallback(this._executeAsync())(callback)
+    promiseToCallback(this.executeAsync())(callback)
   }
 
-  async _executeAsync () {
+  async executeAsync () {
     this.running = true
     // store the promise resolution functions to be resolved at end of queue
     this.execution = {}
@@ -126,10 +126,10 @@ class WorkerQueue {
    * @returns {void}
    */
   processNext (peer, cb) {
-    promiseToCallback(this._processNextAsync(peer))(cb)
+    promiseToCallback(this.processNextAsync(peer))(cb)
   }
 
-  async _processNextAsync (peer) {
+  async processNextAsync (peer) {
     if (!this.running) {
       return
     }
@@ -143,7 +143,7 @@ class WorkerQueue {
     // Check if we've queried enough peers already
     let continueQuerying, continueQueryingError
     try {
-      continueQuerying = await this.run._continueQueryingAsync(this)
+      continueQuerying = await this.run.continueQueryingAsync(this)
     } catch (err) {
       continueQueryingError = err
     }
@@ -175,7 +175,7 @@ class WorkerQueue {
     this.log('queue:work')
     let state, execError
     try {
-      state = await this._execQueryAsync(peer)
+      state = await this.execQueryAsync(peer)
     } catch (err) {
       execError = err
     }
@@ -216,10 +216,10 @@ class WorkerQueue {
    * @private
    */
   execQuery (peer, callback) {
-    promiseToCallback(this._execQueryAsync(peer))(callback)
+    promiseToCallback(this.execQueryAsync(peer))(callback)
   }
 
-  async _execQueryAsync (peer) {
+  async execQueryAsync (peer) {
     let res, queryError
     try {
       res = await this.path.queryFuncAsync(peer)
@@ -259,7 +259,7 @@ class WorkerQueue {
         }
         closer = this.dht.peerBook.put(closer)
         this.dht._peerDiscovered(closer)
-        await this.path._addPeerToQueryAsync(closer.id)
+        await this.path.addPeerToQueryAsync(closer.id)
       }))
     }
   }

--- a/test/peer-queue.spec.js
+++ b/test/peer-queue.spec.js
@@ -5,12 +5,11 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 const PeerId = require('peer-id')
-const series = require('async/series')
 
 const PeerQueue = require('../src/peer-queue')
 
 describe('PeerQueue', () => {
-  it('basics', (done) => {
+  it('basics', async () => {
     const p1 = new PeerId(Buffer.from('11140beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a31'))
     const p2 = new PeerId(Buffer.from('11140beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a32'))
     const p3 = new PeerId(Buffer.from('11140beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33'))
@@ -19,33 +18,26 @@ describe('PeerQueue', () => {
 
     const peer = new PeerId(Buffer.from('11140beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a31'))
 
-    PeerQueue.fromPeerId(peer, (err, pq) => {
-      expect(err).to.not.exist()
+    const pq = await PeerQueue.fromPeerIdAsync(peer)
 
-      series([
-        (cb) => pq.enqueue(p3, cb),
-        (cb) => pq.enqueue(p1, cb),
-        (cb) => pq.enqueue(p2, cb),
-        (cb) => pq.enqueue(p4, cb),
-        (cb) => pq.enqueue(p5, cb),
-        (cb) => pq.enqueue(p1, cb)
-      ], (err) => {
-        expect(err).to.not.exist()
+    await pq.enqueueAsync(p3)
+    await pq.enqueueAsync(p1)
+    await pq.enqueueAsync(p2)
+    await pq.enqueueAsync(p4)
+    await pq.enqueueAsync(p5)
+    await pq.enqueueAsync(p1)
 
-        expect([
-          pq.dequeue(),
-          pq.dequeue(),
-          pq.dequeue(),
-          pq.dequeue(),
-          pq.dequeue(),
-          pq.dequeue()
-        ].map((m) => m.toB58String())).to.be.eql([
-          p1, p1, p1, p4, p3, p2
-        ].map((m) => m.toB58String()))
+    expect([
+      pq.dequeue(),
+      pq.dequeue(),
+      pq.dequeue(),
+      pq.dequeue(),
+      pq.dequeue(),
+      pq.dequeue()
+    ].map((m) => m.toB58String())).to.be.eql([
+      p1, p1, p1, p4, p3, p2
+    ].map((m) => m.toB58String()))
 
-        expect(pq.length).to.be.eql(0)
-        done()
-      })
-    })
+    expect(pq.length).to.be.eql(0)
   })
 })

--- a/test/peer-queue.spec.js
+++ b/test/peer-queue.spec.js
@@ -18,14 +18,14 @@ describe('PeerQueue', () => {
 
     const peer = new PeerId(Buffer.from('11140beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a31'))
 
-    const pq = await PeerQueue.fromPeerIdAsync(peer)
+    const pq = await PeerQueue.fromPeerId(peer)
 
-    await pq.enqueueAsync(p3)
-    await pq.enqueueAsync(p1)
-    await pq.enqueueAsync(p2)
-    await pq.enqueueAsync(p4)
-    await pq.enqueueAsync(p5)
-    await pq.enqueueAsync(p1)
+    await pq.enqueue(p3)
+    await pq.enqueue(p1)
+    await pq.enqueue(p2)
+    await pq.enqueue(p4)
+    await pq.enqueue(p5)
+    await pq.enqueue(p1)
 
     expect([
       pq.dequeue(),

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -9,6 +9,7 @@ const Switch = require('libp2p-switch')
 const TCP = require('libp2p-tcp')
 const Mplex = require('libp2p-mplex')
 const setImmediate = require('async/setImmediate')
+const promiseToCallback = require('promise-to-callback')
 
 const DHT = require('../src')
 const Query = require('../src/query')
@@ -72,7 +73,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    q.run([peerInfos[1].id], (err, res) => {
+    promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
       expect(err).to.not.exist()
       expect(res.paths[0].value).to.eql(Buffer.from('cool'))
       expect(res.paths[0].success).to.eql(true)
@@ -102,7 +103,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    q.run([peerInfos[1].id], (err, res) => {
+    promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
       expect(err).not.to.exist()
 
       // Should have visited
@@ -128,7 +129,7 @@ describe('Query', () => {
     const query = (p, cb) => cb(new Error('fail'))
 
     const q = new Query(dht, peer.id.id, () => query)
-    q.run([peerInfos[1].id], (err, res) => {
+    promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
       expect(err).to.exist()
       expect(err.message).to.eql('fail')
       done()
@@ -141,7 +142,8 @@ describe('Query', () => {
     const query = (p, cb) => {}
 
     const q = new Query(dht, peer.id.id, () => query)
-    q.run([], (err, res) => {
+    promiseToCallback(q.runAsync([]))((err, res) => {
+      if (err) console.error(err)
       expect(err).to.not.exist()
 
       // Should not visit any peers
@@ -165,7 +167,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    q.run([peerInfos[1].id], (err, res) => {
+    promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
       expect(err).to.not.exist()
       expect(res.finalSet.size).to.eql(2)
       done()
@@ -214,7 +216,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    q.run([peerInfos[1].id, peerInfos[2].id, peerInfos[3].id], (err, res) => {
+    promiseToCallback(q.runAsync([peerInfos[1].id, peerInfos[2].id, peerInfos[3].id]))((err, res) => {
       expect(err).to.not.exist()
 
       // Should visit all peers
@@ -255,7 +257,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    q.run([peerInfos[1].id], (err, res) => {
+    promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
       expect(err).to.not.exist()
 
       // Should complete successfully
@@ -315,7 +317,7 @@ describe('Query', () => {
       }
 
       const q = new Query(dhtA, peer.id.id, () => query)
-      q.run([peerInfos[1].id], (err, res) => {
+      promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
         expect(err).to.not.exist()
       })
 
@@ -359,7 +361,7 @@ describe('Query', () => {
       const q = new Query(dhtA, peer.id.id, () => query)
 
       dhtA.stop(() => {
-        q.run([peerInfos[1].id], (err, res) => {
+        promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
           expect(err).to.not.exist()
 
           // Should not visit any peers
@@ -418,7 +420,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    q.run([peerInfos[1].id, peerInfos[4].id], (err, res) => {
+    promiseToCallback(q.runAsync([peerInfos[1].id, peerInfos[4].id]))((err, res) => {
       expect(err).to.not.exist()
 
       // We should get back the values from both paths
@@ -487,7 +489,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    q.run([peerInfos[1].id, peerInfos[4].id], (err, res) => {
+    promiseToCallback(q.runAsync([peerInfos[1].id, peerInfos[4].id]))((err, res) => {
       expect(err).to.not.exist()
 
       // We should only get back the value from the path 4 -> 5
@@ -566,7 +568,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    q.run([peerInfos[1].id, peerInfos[4].id], (err, res) => {
+    promiseToCallback(q.runAsync([peerInfos[1].id, peerInfos[4].id]))((err, res) => {
       expect(err).to.not.exist()
 
       // We should only get back the value from the path 1 -> 2 -> 3
@@ -647,7 +649,7 @@ describe('Query', () => {
         }
 
         const q = new Query(dht, peerInfos[0].id.id, () => query)
-        q.run(initial, (err, res) => {
+        promiseToCallback(q.runAsync(initial))((err, res) => {
           expect(err).to.not.exist()
 
           // Should query 19 peers, then find some peers closer to the key, and
@@ -721,7 +723,7 @@ describe('Query', () => {
       q.concurrency = 1
       // due to round-robin allocation of peers from starts, first
       // path is good, second bad
-      q.run(starts, (err, res) => {
+      promiseToCallback(q.runAsync(starts))((err, res) => {
         expect(err).to.not.exist()
         // we should reach the target node
         expect(targetVisited).to.eql(true)
@@ -747,7 +749,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    q.run([peerInfos[1].id], (err, res) => {
+    promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
       expect(err).to.not.exist()
     })
 

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -73,7 +73,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
+    promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
       expect(err).to.not.exist()
       expect(res.paths[0].value).to.eql(Buffer.from('cool'))
       expect(res.paths[0].success).to.eql(true)
@@ -103,7 +103,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
+    promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
       expect(err).not.to.exist()
 
       // Should have visited
@@ -129,7 +129,7 @@ describe('Query', () => {
     const query = (p, cb) => cb(new Error('fail'))
 
     const q = new Query(dht, peer.id.id, () => query)
-    promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
+    promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
       expect(err).to.exist()
       expect(err.message).to.eql('fail')
       done()
@@ -142,7 +142,7 @@ describe('Query', () => {
     const query = (p, cb) => {}
 
     const q = new Query(dht, peer.id.id, () => query)
-    promiseToCallback(q.runAsync([]))((err, res) => {
+    promiseToCallback(q.run([]))((err, res) => {
       if (err) console.error(err)
       expect(err).to.not.exist()
 
@@ -167,7 +167,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
+    promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
       expect(err).to.not.exist()
       expect(res.finalSet.size).to.eql(2)
       done()
@@ -216,7 +216,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    promiseToCallback(q.runAsync([peerInfos[1].id, peerInfos[2].id, peerInfos[3].id]))((err, res) => {
+    promiseToCallback(q.run([peerInfos[1].id, peerInfos[2].id, peerInfos[3].id]))((err, res) => {
       expect(err).to.not.exist()
 
       // Should visit all peers
@@ -257,7 +257,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
+    promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
       expect(err).to.not.exist()
 
       // Should complete successfully
@@ -317,7 +317,7 @@ describe('Query', () => {
       }
 
       const q = new Query(dhtA, peer.id.id, () => query)
-      promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
+      promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
         expect(err).to.not.exist()
       })
 
@@ -361,7 +361,7 @@ describe('Query', () => {
       const q = new Query(dhtA, peer.id.id, () => query)
 
       dhtA.stop(() => {
-        promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
+        promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
           expect(err).to.not.exist()
 
           // Should not visit any peers
@@ -420,7 +420,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    promiseToCallback(q.runAsync([peerInfos[1].id, peerInfos[4].id]))((err, res) => {
+    promiseToCallback(q.run([peerInfos[1].id, peerInfos[4].id]))((err, res) => {
       expect(err).to.not.exist()
 
       // We should get back the values from both paths
@@ -489,7 +489,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    promiseToCallback(q.runAsync([peerInfos[1].id, peerInfos[4].id]))((err, res) => {
+    promiseToCallback(q.run([peerInfos[1].id, peerInfos[4].id]))((err, res) => {
       expect(err).to.not.exist()
 
       // We should only get back the value from the path 4 -> 5
@@ -568,7 +568,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    promiseToCallback(q.runAsync([peerInfos[1].id, peerInfos[4].id]))((err, res) => {
+    promiseToCallback(q.run([peerInfos[1].id, peerInfos[4].id]))((err, res) => {
       expect(err).to.not.exist()
 
       // We should only get back the value from the path 1 -> 2 -> 3
@@ -649,7 +649,7 @@ describe('Query', () => {
         }
 
         const q = new Query(dht, peerInfos[0].id.id, () => query)
-        promiseToCallback(q.runAsync(initial))((err, res) => {
+        promiseToCallback(q.run(initial))((err, res) => {
           expect(err).to.not.exist()
 
           // Should query 19 peers, then find some peers closer to the key, and
@@ -723,7 +723,7 @@ describe('Query', () => {
       q.concurrency = 1
       // due to round-robin allocation of peers from starts, first
       // path is good, second bad
-      promiseToCallback(q.runAsync(starts))((err, res) => {
+      promiseToCallback(q.run(starts))((err, res) => {
         expect(err).to.not.exist()
         // we should reach the target node
         expect(targetVisited).to.eql(true)
@@ -749,7 +749,7 @@ describe('Query', () => {
     }
 
     const q = new Query(dht, peer.id.id, () => query)
-    promiseToCallback(q.runAsync([peerInfos[1].id]))((err, res) => {
+    promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
       expect(err).to.not.exist()
     })
 

--- a/test/query/index.spec.js
+++ b/test/query/index.spec.js
@@ -9,6 +9,7 @@ const expect = chai.expect
 const sinon = require('sinon')
 const each = require('async/each')
 const PeerBook = require('peer-book')
+const promiseToCallback = require('promise-to-callback')
 
 const Query = require('../../src/query')
 const Path = require('../../src/query/path')
@@ -71,7 +72,7 @@ describe('Query', () => {
       let query = new Query(dht, targetKey.key, () => querySpy)
 
       let run = new Run(query)
-      run.init(() => {
+      promiseToCallback(run.initAsync())(() => {
         // Add the sorted peers into 5 paths. This will weight
         // the paths with increasingly further peers
         let sortedPeerIds = sortedPeers.map(peerInfo => peerInfo.id)
@@ -96,7 +97,7 @@ describe('Query', () => {
           const continueSpy = sinon.spy(run, 'continueQueryingAsync')
 
           // Run the 4 paths
-          run.executePaths(paths, (err) => {
+          promiseToCallback(run.executePathsAsync(paths))((err) => {
             expect(err).to.not.exist()
             // The resulting peers should all be from path 0 as it had the closest
             expect(run.peersQueried.peers).to.eql(paths[0].initialPeers)
@@ -125,7 +126,7 @@ describe('Query', () => {
       let query = new Query(dht, targetKey.key, () => querySpy)
 
       let run = new Run(query)
-      run.init(() => {
+      promiseToCallback(run.initAsync())(() => {
         let sortedPeerIds = sortedPeers.map(peerInfo => peerInfo.id)
 
         // Take the top 15 peers and peers 20 - 25 to seed `run.peersQueried`
@@ -156,7 +157,7 @@ describe('Query', () => {
           if (err) return done(err)
 
           // Run the path
-          run.executePaths([path], (err) => {
+          promiseToCallback(run.executePathsAsync([path]))((err) => {
             expect(err).to.not.exist()
 
             // Querying will stop after the first ALPHA peers are queried

--- a/test/query/index.spec.js
+++ b/test/query/index.spec.js
@@ -93,7 +93,7 @@ describe('Query', () => {
         }, (err) => {
           if (err) return done(err)
 
-          const continueSpy = sinon.spy(run, 'continueQuerying')
+          const continueSpy = sinon.spy(run, '_continueQueryingAsync')
 
           // Run the 4 paths
           run.executePaths(paths, (err) => {
@@ -146,8 +146,8 @@ describe('Query', () => {
         const returnPeers = sortedPeers.slice(16, 20)
         // When the second query happens, which is a further peer,
         // return peers 16 - 19
-        querySpy.onCall(1).callsArgWith(1, null, {
-          closerPeers: returnPeers
+        querySpy.onCall(1).callsFake((_, cb) => {
+          setTimeout(() => cb(null, { closerPeers: returnPeers }), 10)
         })
 
         each(queriedPeers, (peerId, cb) => {

--- a/test/query/index.spec.js
+++ b/test/query/index.spec.js
@@ -93,7 +93,7 @@ describe('Query', () => {
         }, (err) => {
           if (err) return done(err)
 
-          const continueSpy = sinon.spy(run, '_continueQueryingAsync')
+          const continueSpy = sinon.spy(run, 'continueQueryingAsync')
 
           // Run the 4 paths
           run.executePaths(paths, (err) => {

--- a/test/query/index.spec.js
+++ b/test/query/index.spec.js
@@ -72,7 +72,7 @@ describe('Query', () => {
       let query = new Query(dht, targetKey.key, () => querySpy)
 
       let run = new Run(query)
-      promiseToCallback(run.initAsync())(() => {
+      promiseToCallback(run.init())(() => {
         // Add the sorted peers into 5 paths. This will weight
         // the paths with increasingly further peers
         let sortedPeerIds = sortedPeers.map(peerInfo => peerInfo.id)
@@ -94,10 +94,10 @@ describe('Query', () => {
         }, (err) => {
           if (err) return done(err)
 
-          const continueSpy = sinon.spy(run, 'continueQueryingAsync')
+          const continueSpy = sinon.spy(run, 'continueQuerying')
 
           // Run the 4 paths
-          promiseToCallback(run.executePathsAsync(paths))((err) => {
+          promiseToCallback(run.executePaths(paths))((err) => {
             expect(err).to.not.exist()
             // The resulting peers should all be from path 0 as it had the closest
             expect(run.peersQueried.peers).to.eql(paths[0].initialPeers)
@@ -126,7 +126,7 @@ describe('Query', () => {
       let query = new Query(dht, targetKey.key, () => querySpy)
 
       let run = new Run(query)
-      promiseToCallback(run.initAsync())(() => {
+      promiseToCallback(run.init())(() => {
         let sortedPeerIds = sortedPeers.map(peerInfo => peerInfo.id)
 
         // Take the top 15 peers and peers 20 - 25 to seed `run.peersQueried`
@@ -157,7 +157,7 @@ describe('Query', () => {
           if (err) return done(err)
 
           // Run the path
-          promiseToCallback(run.executePathsAsync([path]))((err) => {
+          promiseToCallback(run.executePaths([path]))((err) => {
             expect(err).to.not.exist()
 
             // Querying will stop after the first ALPHA peers are queried


### PR DESCRIPTION
non-breaking async refactor for
- `Query`
- `Run`
- `Path` 
- `PeerQueue`

this is intended to *not* introduce any changes in behavior

related #82 