### PR TITLE
refactor(async): WorkerQueue

### DIFF
--- a/src/query/index.js
+++ b/src/query/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const mh = require('multihashes')
-const promisify = require('promisify-es6')
 const promiseToCallback = require('promise-to-callback')
 
 const utils = require('../utils')
@@ -75,7 +74,7 @@ class Query {
     this._log(`query running with K=${this.dht.kBucketSize}, A=${this.dht.concurrency}, D=${Math.min(this.dht.disjointPaths, peers.length)}`)
     this._run.once('start', this._onStart)
     this._run.once('complete', this._onComplete)
-    return promisify(cb => this._run.execute(peers, cb))()
+    return this._run._executeAsync(peers)
   }
 
   /**

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -136,8 +136,8 @@ class Run extends EventEmitter {
   }
 
   async _workerQueueAsync (path) {
-    await promisify(cb => this.init(cb))()
-    return promisify(cb => this.startWorker(path, cb))()
+    await this._initAsync()
+    await this._startWorkerAsync(path)
   }
 
   /**

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -109,7 +109,7 @@ class Run extends EventEmitter {
 
     this.emit('start')
     try {
-      await promisify(callback => each(paths, (path, cb) => path.execute(cb), callback))()
+      await Promise.all(paths.map(path => path._executeAsync()))
     } finally {
       // Ensure all workers are stopped
       this.stop()

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -215,6 +215,8 @@ class Run extends EventEmitter {
     // Check if any of the peers that are currently being queried are closer
     // to the key than the peers we've already queried
     const someCloser = await promisify(cb => this.peersQueried.anyCloser(running, cb))()
+    // this line affects the number of times the queryFn is called in some situation
+    await new Promise(resolve => setImmediate(resolve))
 
     // Some are closer, the worker should keep going
     if (someCloser) {

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -3,6 +3,9 @@
 const PeerDistanceList = require('../peer-distance-list')
 const EventEmitter = require('events')
 const each = require('async/each')
+const promisify = require('promisify-es6')
+const promiseToCallback = require('promise-to-callback')
+
 const Path = require('./path')
 const WorkerQueue = require('./workerQueue')
 const utils = require('../utils')
@@ -54,6 +57,10 @@ class Run extends EventEmitter {
    * @param {function(Error, Object)} callback
    */
   execute (peers, callback) {
+    promiseToCallback(this._executeAsync(peers))(callback)
+  }
+
+  async _executeAsync (peers) {
     const paths = [] // array of states per disjoint path
 
     // Create disjoint paths
@@ -68,27 +75,23 @@ class Run extends EventEmitter {
     })
 
     // Execute the query along each disjoint path
-    this.executePaths(paths, (err) => {
-      if (err) {
-        return callback(err)
-      }
+    await this._executePathsAsync(paths)
 
-      const res = {
-        // The closest K peers we were able to query successfully
-        finalSet: new Set(this.peersQueried.peers),
-        paths: []
-      }
+    const res = {
+      // The closest K peers we were able to query successfully
+      finalSet: new Set(this.peersQueried.peers),
+      paths: []
+    }
 
-      // Collect the results from each completed path
-      for (const path of paths) {
-        if (path.res && (path.res.pathComplete || path.res.queryComplete)) {
-          path.res.success = true
-          res.paths.push(path.res)
-        }
+    // Collect the results from each completed path
+    for (const path of paths) {
+      if (path.res && (path.res.pathComplete || path.res.queryComplete)) {
+        path.res.success = true
+        res.paths.push(path.res)
       }
+    }
 
-      callback(err, res)
-    })
+    return res
   }
 
   /**
@@ -98,28 +101,29 @@ class Run extends EventEmitter {
    * @param {function(Error)} callback
    */
   executePaths (paths, callback) {
+    promiseToCallback(this._executePathsAsync(paths))(callback)
+  }
+
+  async _executePathsAsync (paths) {
     this.running = true
 
     this.emit('start')
-    each(paths, (path, cb) => path.execute(cb), (err) => {
+    try {
+      await promisify(callback => each(paths, (path, cb) => path.execute(cb), callback))()
+    } catch (err) {
+      throw err
+    } finally {
       // Ensure all workers are stopped
       this.stop()
-
       // Completed the Run
       this.emit('complete')
+    }
 
-      if (err) {
-        return callback(err)
-      }
-
-      // If all queries errored out, something is seriously wrong, so callback
-      // with an error
-      if (this.errors.length === this.peersSeen.size) {
-        return callback(this.errors[0])
-      }
-
-      callback()
-    })
+    // If all queries errored out, something is seriously wrong, so callback
+    // with an error
+    if (this.errors.length === this.peersSeen.size) {
+      throw this.errors[0]
+    }
   }
 
   /**
@@ -130,7 +134,12 @@ class Run extends EventEmitter {
    * @param {function(Error)} callback
    */
   workerQueue (path, callback) {
-    this.init(() => this.startWorker(path, callback))
+    promiseToCallback(this._workerQueueAsync(path))(callback)
+  }
+
+  async _workerQueueAsync (path) {
+    await promisify(cb => this.init(cb))()
+    return promisify(cb => this.startWorker(path, cb))()
   }
 
   /**
@@ -140,9 +149,13 @@ class Run extends EventEmitter {
    * @param {function(Error)} callback
    */
   startWorker (path, callback) {
+    promiseToCallback(this._startWorkerAsync(path))(callback)
+  }
+
+  async _startWorkerAsync (path) {
     const worker = new WorkerQueue(this.query.dht, this, path, this.query._log)
     this.workers.push(worker)
-    worker.execute(callback)
+    return promisify(cb => worker.execute(cb))()
   }
 
   /**
@@ -153,28 +166,29 @@ class Run extends EventEmitter {
    * @returns {void}
    */
   init (callback) {
-    if (this.peersQueried) {
-      return callback()
-    }
+    promiseToCallback(this._initAsync())(callback)
+  }
 
-    // We only want to initialize it once for the run, and then inform each
-    // path worker that it's ready
-    if (this.awaitingKey) {
-      this.awaitingKey.push(callback)
+  async _initAsync () {
+    if (this.peersQueried) {
       return
     }
 
-    this.awaitingKey = [callback]
+    // We only want to initialize the PeerDistanceList once for the run
+    if (this.peersQueriedPromise) {
+      await this.peersQueriedPromise
+      return
+    }
 
-    // Convert the key into a DHT key by hashing it
-    utils.convertBuffer(this.query.key, (err, dhtKey) => {
+    // This promise is temporarily stored so that others may await its completion
+    this.peersQueriedPromise = (async () => {
+      const dhtKey = await promisify(cb => utils.convertBuffer(this.query.key, cb))()
       this.peersQueried = new PeerDistanceList(dhtKey, this.query.dht.kBucketSize)
+    })()
 
-      for (const cb of this.awaitingKey) {
-        cb(err)
-      }
-      this.awaitingKey = undefined
-    })
+    // After PeerDistanceList is initialized, clean up
+    await this.peersQueriedPromise
+    delete this.peersQueriedPromise
   }
 
   /**
@@ -187,9 +201,13 @@ class Run extends EventEmitter {
    * @returns {void}
    */
   continueQuerying (worker, callback) {
+    promiseToCallback(this._continueQueryingAsync(worker))(callback)
+  }
+
+  async _continueQueryingAsync (worker) {
     // If we haven't queried K peers yet, keep going
     if (this.peersQueried.length < this.peersQueried.capacity) {
-      return callback(null, true)
+      return true
     }
 
     // Get all the peers that are currently being queried.
@@ -199,19 +217,15 @@ class Run extends EventEmitter {
 
     // Check if any of the peers that are currently being queried are closer
     // to the key than the peers we've already queried
-    this.peersQueried.anyCloser(running, (err, someCloser) => {
-      if (err) {
-        return callback(err)
-      }
+    const someCloser = await promisify(cb => this.peersQueried.anyCloser(running, cb))()
 
-      // Some are closer, the worker should keep going
-      if (someCloser) {
-        return callback(null, true)
-      }
+    // Some are closer, the worker should keep going
+    if (someCloser) {
+      return true
+    }
 
-      // None are closer, the worker can stop
-      callback(null, false)
-    })
+    // None are closer, the worker can stop
+    return false
   }
 }
 

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -110,8 +110,6 @@ class Run extends EventEmitter {
     this.emit('start')
     try {
       await promisify(callback => each(paths, (path, cb) => path.execute(cb), callback))()
-    } catch (err) {
-      throw err
     } finally {
       // Ensure all workers are stopped
       this.stop()

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -2,7 +2,6 @@
 
 const PeerDistanceList = require('../peer-distance-list')
 const EventEmitter = require('events')
-const each = require('async/each')
 const promisify = require('promisify-es6')
 const promiseToCallback = require('promise-to-callback')
 

--- a/src/query/workerQueue.js
+++ b/src/query/workerQueue.js
@@ -1,7 +1,8 @@
 'use strict'
 
-const each = require('async/each')
 const queue = require('async/queue')
+const promisify = require('promisify-es6')
+const promiseToCallback = require('promise-to-callback')
 
 class WorkerQueue {
   /**
@@ -20,6 +21,9 @@ class WorkerQueue {
 
     this.concurrency = this.dht.concurrency
     this.queue = this.setupQueue()
+    // a container for resolve/reject functions that will be populated
+    // when execute() is called
+    this.execution = null
   }
 
   /**
@@ -68,7 +72,11 @@ class WorkerQueue {
     this.running = false
     this.queue.kill()
     this.log('worker:stop, %d workers still running', this.run.workers.filter(w => w.running).length)
-    this.callbackFn(err)
+    if (err) {
+      this.execution.reject(err)
+    } else {
+      this.execution.resolve()
+    }
   }
 
   /**
@@ -78,9 +86,18 @@ class WorkerQueue {
    * @param {function(Error)} callback
    */
   execute (callback) {
+    promiseToCallback(this._executeAsync())(callback)
+  }
+
+  async _executeAsync () {
     this.running = true
-    this.callbackFn = callback
+    // store the promise resolution functions to be resolved at end of queue
+    this.execution = {}
+    const execPromise = new Promise((resolve, reject) => Object.assign(this.execution, { resolve, reject }))
+    // start queue
     this.fill()
+    // await completion
+    await execPromise
   }
 
   /**
@@ -109,73 +126,85 @@ class WorkerQueue {
    * @returns {void}
    */
   processNext (peer, cb) {
+    promiseToCallback(this._processNextAsync(peer))(cb)
+  }
+
+  async _processNextAsync (peer) {
     if (!this.running) {
-      return cb()
+      return
     }
 
     // The paths must be disjoint, meaning that no two paths in the Query may
     // traverse the same peer
     if (this.run.peersSeen.has(peer)) {
-      return cb()
+      return
     }
 
     // Check if we've queried enough peers already
-    this.run.continueQuerying(this, (err, continueQuerying) => {
-      if (!this.running) {
-        return cb()
-      }
+    let continueQuerying, continueQueryingError
+    try {
+      continueQuerying = await this.run._continueQueryingAsync(this)
+    } catch (err) {
+      continueQueryingError = err
+    }
 
-      if (err) {
-        return cb(err)
-      }
+    // Abort and ignore any error if we're no longer running
+    if (!this.running) {
+      return
+    }
 
-      // No peer we're querying is closer stop the queue
-      // This will cause queries that may potentially result in
-      // closer nodes to be ended, but it reduces overall query time
-      if (!continueQuerying) {
-        this.stop()
-        return cb()
-      }
+    if (continueQueryingError) {
+      throw continueQueryingError
+    }
 
-      // Check if another path has queried this peer in the mean time
-      if (this.run.peersSeen.has(peer)) {
-        return cb()
-      }
-      this.run.peersSeen.add(peer)
+    // No peer we're querying is closer, stop the queue
+    // This will cause queries that may potentially result in
+    // closer nodes to be ended, but it reduces overall query time
+    if (!continueQuerying) {
+      this.stop()
+      return
+    }
 
-      // Execute the query on the next peer
-      this.log('queue:work')
-      this.execQuery(peer, (err, state) => {
-        // Ignore response after worker killed
-        if (!this.running) {
-          return cb()
-        }
+    // Check if another path has queried this peer in the mean time
+    if (this.run.peersSeen.has(peer)) {
+      return
+    }
+    this.run.peersSeen.add(peer)
 
-        this.log('queue:work:done', err, state)
-        if (err) {
-          return cb(err)
-        }
+    // Execute the query on the next peer
+    this.log('queue:work')
+    let state, execError
+    try {
+      state = await this._execQueryAsync(peer)
+    } catch (err) {
+      execError = err
+    }
 
-        // If query is complete, stop all workers.
-        // Note: run.stop() calls stop() on all the workers, which kills the
-        // queue and calls callbackFn()
-        if (state && state.queryComplete) {
-          this.log('query:complete')
-          this.run.stop()
-          return cb()
-        }
+    // Abort and ignore any error if we're no longer running
+    if (!this.running) {
+      return
+    }
 
-        // If path is complete, just stop this worker.
-        // Note: this.stop() kills the queue and calls callbackFn()
-        if (state && state.pathComplete) {
-          this.stop()
-          return cb()
-        }
+    this.log('queue:work:done', execError, state)
 
-        // Otherwise, process next peer
-        cb()
-      })
-    })
+    if (execError) {
+      throw execError
+    }
+
+    // If query is complete, stop all workers.
+    // Note: run.stop() calls stop() on all the workers, which kills the
+    // queue and resolves execution
+    if (state && state.queryComplete) {
+      this.log('query:complete')
+      this.run.stop()
+      return
+    }
+
+    // If path is complete, just stop this worker.
+    // Note: this.stop() kills the queue and resolves execution
+    if (state && state.pathComplete) {
+      this.stop()
+    }
   }
 
   /**
@@ -187,49 +216,52 @@ class WorkerQueue {
    * @private
    */
   execQuery (peer, callback) {
-    this.path.queryFunc(peer, (err, res) => {
-      // If the run has completed, bail out
-      if (!this.running) {
-        return callback()
+    promiseToCallback(this._execQueryAsync(peer))(callback)
+  }
+
+  async _execQueryAsync (peer) {
+    let res, queryError
+    try {
+      res = await this.path.queryFuncAsync(peer)
+    } catch (err) {
+      queryError = err
+    }
+
+    // Abort and ignore any error if we're no longer running
+    if (!this.running) {
+      return
+    }
+
+    if (queryError) {
+      this.run.errors.push(queryError)
+      return
+    }
+
+    // Add the peer to the closest peers we have successfully queried
+    await promisify(cb => this.run.peersQueried.add(peer, cb))()
+
+    // If the query indicates that this path or the whole query is complete
+    // set the path result and bail out
+    if (res.pathComplete || res.queryComplete) {
+      this.path.res = res
+      return {
+        pathComplete: res.pathComplete,
+        queryComplete: res.queryComplete
       }
+    }
 
-      if (err) {
-        this.run.errors.push(err)
-        return callback()
-      }
-
-      // Add the peer to the closest peers we have successfully queried
-      this.run.peersQueried.add(peer, (err) => {
-        if (err) {
-          return callback(err)
+    // If there are closer peers to query, add them to the queue
+    if (res.closerPeers && res.closerPeers.length > 0) {
+      await Promise.all(res.closerPeers.map(async (closer) => {
+        // don't add ourselves
+        if (this.dht._isSelf(closer.id)) {
+          return
         }
-
-        // If the query indicates that this path or the whole query is complete
-        // set the path result and bail out
-        if (res.pathComplete || res.queryComplete) {
-          this.path.res = res
-          return callback(null, {
-            pathComplete: res.pathComplete,
-            queryComplete: res.queryComplete
-          })
-        }
-
-        // If there are closer peers to query, add them to the queue
-        if (res.closerPeers && res.closerPeers.length > 0) {
-          return each(res.closerPeers, (closer, cb) => {
-            // don't add ourselves
-            if (this.dht._isSelf(closer.id)) {
-              return cb()
-            }
-            closer = this.dht.peerBook.put(closer)
-            this.dht._peerDiscovered(closer)
-            this.path.addPeerToQuery(closer.id, cb)
-          }, callback)
-        }
-
-        callback()
-      })
-    })
+        closer = this.dht.peerBook.put(closer)
+        this.dht._peerDiscovered(closer)
+        await this.path._addPeerToQueryAsync(closer.id)
+      }))
+    }
   }
 }
 

--- a/test/query/index.spec.js
+++ b/test/query/index.spec.js
@@ -93,7 +93,7 @@ describe('Query', () => {
         }, (err) => {
           if (err) return done(err)
 
-          const continueSpy = sinon.spy(run, 'continueQuerying')
+          const continueSpy = sinon.spy(run, '_continueQueryingAsync')
 
           // Run the 4 paths
           run.executePaths(paths, (err) => {

--- a/test/query/index.spec.js
+++ b/test/query/index.spec.js
@@ -146,8 +146,8 @@ describe('Query', () => {
         const returnPeers = sortedPeers.slice(16, 20)
         // When the second query happens, which is a further peer,
         // return peers 16 - 19
-        querySpy.onCall(1).callsArgWith(1, null, {
-          closerPeers: returnPeers
+        querySpy.onCall(1).callsFake((_, cb) => {
+          setTimeout(() => cb(null, { closerPeers: returnPeers }), 10)
         })
 
         each(queriedPeers, (peerId, cb) => {


### PR DESCRIPTION
putting up this incomplete PR for discussion on test failures

this diff https://github.com/libp2p/js-libp2p-kad-dht/commit/bce9556d41e94e69fbe0a7d51b2444abeddc9a9c triggers these test failure https://gist.github.com/kumavis/34ed55927b6749645d0d1c8406c39ef1

this line https://github.com/libp2p/js-libp2p-kad-dht/commit/bce9556d41e94e69fbe0a7d51b2444abeddc9a9c#diff-ef69a013ba3a73c2ad2672948fb7bab9R219 changes this error

```
Uncaught AssertionError: expected 9 to deeply equal 3
 ```
to
```
Uncaught AssertionError: expected 8 to deeply equal 3
 ```
from this assertion https://github.com/libp2p/js-libp2p-kad-dht/blob/bce9556d41e94e69fbe0a7d51b2444abeddc9a9c/test/query/index.spec.js#L163

includes commits from https://github.com/libp2p/js-libp2p-kad-dht/pull/120