### PR TITLE
Bug Fix: correctly calculate pathSize in _findNProviders

### DIFF
--- a/src/private.js
+++ b/src/private.js
@@ -538,7 +538,7 @@ module.exports = (dht) => ({
     const paths = []
     const query = new Query(dht, key.buffer, (pathIndex, numPaths) => {
       // This function body runs once per disjoint path
-      const pathSize = utils.pathSize(out.length - n, numPaths)
+      const pathSize = utils.pathSize(n - out.length, numPaths)
       const pathProviders = new LimitedPeerList(pathSize)
       paths.push(pathProviders)
 


### PR DESCRIPTION
I noticed negative values for `pathSize`