### PR TITLE
Feature Request - query internal data

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "cids": "~0.7.0",
     "debug": "^4.1.1",
     "err-code": "^1.1.2",
+    "fromentries": "^1.1.0",
     "hashlru": "^2.3.0",
     "heap": "~0.2.6",
     "interface-datastore": "~0.6.0",

--- a/src/private.js
+++ b/src/private.js
@@ -538,7 +538,7 @@ module.exports = (dht) => ({
     const paths = []
     const query = new Query(dht, key.buffer, (pathIndex, numPaths) => {
       // This function body runs once per disjoint path
-      const pathSize = utils.pathSize(out.length - n, numPaths)
+      const pathSize = utils.pathSize(n - out.length, numPaths)
       const pathProviders = new LimitedPeerList(pathSize)
       paths.push(pathProviders)
 

--- a/src/private.js
+++ b/src/private.js
@@ -7,6 +7,7 @@ const timeout = require('async/timeout')
 const PeerInfo = require('peer-info')
 const promisify = require('promisify-es6')
 const promiseToCallback = require('promise-to-callback')
+const fromEntries = require('fromentries')
 
 const errcode = require('err-code')
 
@@ -515,6 +516,11 @@ module.exports = (dht) => ({
   },
 
   async _findNProvidersAsync (key, providerTimeout, n) {
+    const { result } = await _findNProvidersWithStatsAsync(key, providerTimeout, n)
+    return result
+  },
+
+  async _findNProvidersWithStatsAsync (key, providerTimeout, n) {
     const out = new LimitedPeerList(n)
 
     const provs = await promisify(cb => dht.providers.getProviders(key, cb))()
@@ -536,19 +542,36 @@ module.exports = (dht) => ({
 
     // need more, query the network
     const paths = []
+    const pathIntroductions = []
+    const localCount = out.length
+
     const query = new Query(dht, key.buffer, (pathIndex, numPaths) => {
       // This function body runs once per disjoint path
-      const pathSize = utils.pathSize(n - out.length, numPaths)
+      const pathSize = utils.pathSize(n - localCount, numPaths)
       const pathProviders = new LimitedPeerList(pathSize)
       paths.push(pathProviders)
 
+      const introductions = {}
+      pathIntroductions.push(introductions)
+
       // Here we return the query function to use on this particular disjoint path
       return (peer, cb) => {
+        const peerId = peer.toB58String()
         waterfall([
           (cb) => dht._findProvidersSingle(peer, key, cb),
           (msg, cb) => {
             const provs = msg.providerPeers
             dht._log('(%s) found %s provider entries', dht.peerInfo.id.toB58String(), provs.length)
+
+            const peerIntros = []
+            introductions[peerId] = peerIntros
+
+            const uniqProvs = Array.from(new Set(msg.providerPeers.map(p => p.id.toB58String())))
+            const uniqClos = Array.from(new Set(msg.closerPeers.map(p => p.id.toB58String())))
+            console.log(`${peerId} introed ${msg.providerPeers.length} (${uniqProvs.length}) provs and ${msg.closerPeers.length} (${uniqClos.length}) closer`)
+
+            uniqProvs.forEach(id => peerIntros.push(id))
+            uniqClos.forEach(id => peerIntros.push(id))
 
             provs.forEach((prov) => {
               pathProviders.push(dht.peerBook.put(prov))
@@ -587,7 +610,17 @@ module.exports = (dht) => ({
       })
     })
 
-    return out.toArray()
+    const queryStats = {
+      localCount,
+      paths: query._run.paths.map((path, pathIndex) => ({
+        initialPeers: path.initialPeers.map(p => p.toB58String()),
+        introductions: pathIntroductions[pathIndex],
+      }))
+    }
+
+    const result = out.toArray()
+
+    return { result, queryStats }
   },
 
   /**

--- a/src/query/run.js
+++ b/src/query/run.js
@@ -54,7 +54,7 @@ class Run extends EventEmitter {
    * @param {function(Error, Object)} callback
    */
   execute (peers, callback) {
-    const paths = [] // array of states per disjoint path
+    const paths = this.paths = [] // array of states per disjoint path
 
     // Create disjoint paths
     const numPaths = Math.min(this.query.dht.disjointPaths, peers.length)


### PR DESCRIPTION
This is a quick hack for getting some internal info from the queries. I used this to start building some graphs that show off the query flow.

![image](https://user-images.githubusercontent.com/1474978/57984767-9169fe00-7a91-11e9-8f31-f22ae9124d55.png)
![image (1)](https://user-images.githubusercontent.com/1474978/57984769-929b2b00-7a91-11e9-8a23-4654deb17bc8.png)
```
pink - query initiator
orange - query initial peer
yellow - introduced
green - provider
blue - uninvolved
black - uninvolved and not connected to telemetry
```

note: for layout-circle the positions are random, not based on peerId, though I should do that next

a link means someone suggested someone as a closer peer or provider, or connects query initiator to initial peers 
changing circle-layout to position by peerId will give an interesting look at how querys hone in on a result

It would be nice if possible to gather this info generically at the query layer, but here I put some extra info in the queryFn. When doing it all in the queryFn, the only thing missing was the initialPeers for the path. Though, in the end, I didn't need anything in the graph that was specific to a Path, but it could be helpful debugging and testing queries in the future.