### PR TITLE
chore: remove commitlint and pre-push test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ jobs:
     - stage: check
       script:
         - npx aegir build --bundlesize
-        - npx aegir commitlint --travis
         - npx aegir dep-check
         - npm run lint
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "sim": "node test/simulation/index.js"
   },
   "pre-push": [
-    "lint",
-    "test"
+    "lint"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
This does 2 things:

1. Removes commitlint on Travis: We shouldnt block travis builds with commitlint. Instead, we should ensure commit messages are formatted correctly by updating the messages via squashing merging the PRs. This keeps the barrier to entry low, while allowing maintainers to keep changelog messaging clean.

2. Removes test running on pre-push. Linting is fine, but the test suite is rather long, let's have CI take care of that.