### PR TITLE
Fix: send correct payload in ADD_PROVIDER RPC

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,4 +1,4 @@
 module.exports = {
-    bundlesize: { maxSize: '196kB' }
+    bundlesize: { maxSize: '197kB' }
 }
   

--- a/src/index.js
+++ b/src/index.js
@@ -541,7 +541,7 @@ class KadDHT extends EventEmitter {
       (cb) => this.getClosestPeers(key.buffer, cb),
       (peers, cb) => {
         const msg = new Message(Message.TYPES.ADD_PROVIDER, key.buffer, 0)
-        msg.providerPeers = peers.map((p) => new PeerInfo(p))
+        msg.providerPeers = [this.peerInfo]
 
         each(peers, (peer, cb) => {
           this._log('putProvider %s to %s', key.toBaseEncodedString(), peer.toB58String())

--- a/test/rpc/handlers/add-provider.spec.js
+++ b/test/rpc/handlers/add-provider.spec.js
@@ -53,9 +53,6 @@ describe('rpc - handlers - AddProvider', () => {
       message: new Message(Message.TYPES.ADD_PROVIDER, Buffer.alloc(0), 0),
       error: 'ERR_MISSING_KEY'
     }, {
-      message: new Message(Message.TYPES.ADD_PROVIDER, Buffer.alloc(0), 0),
-      error: 'ERR_MISSING_KEY'
-    }, {
       message: new Message(Message.TYPES.ADD_PROVIDER, Buffer.from('hello world'), 0),
       error: 'ERR_INVALID_CID'
     }]


### PR DESCRIPTION
In the payload for ADD_PROVIDER we were sending remote peers their own id instead of the local node's id. The tests still passed because on the receiving end we ignore the payload and just look at the connection to get the provider peer id.