### PR TITLE
Async Refactor: query functions are now async functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -363,7 +363,6 @@ class KadDHT extends EventEmitter {
 
               const res = { closerPeers: peers }
 
-              if (lookupErr) console.log('lookupErr', lookupErr)
               if ((rec && rec.value) || lookupErr) {
                 pathVals.push({
                   val: rec && rec.value,

--- a/src/index.js
+++ b/src/index.js
@@ -347,31 +347,36 @@ class KadDHT extends EventEmitter {
             paths.push(pathVals)
 
             // Here we return the query function to use on this particular disjoint path
-            return (peer, cb) => {
-              this._getValueOrPeers(peer, key, (err, rec, peers) => {
-                if (err) {
-                  // If we have an invalid record we just want to continue and fetch a new one.
-                  if (!(err.code === 'ERR_INVALID_RECORD')) {
-                    return cb(err)
-                  }
+            return async (peer) => {
+              let rec, peers, lookupErr
+              try {
+                const results = await this._getValueOrPeersAsync(peer, key)
+                rec = results.record
+                peers = results.peers
+              } catch (err) {
+                // If we have an invalid record we just want to continue and fetch a new one.
+                if (err.code !== 'ERR_INVALID_RECORD') {
+                  throw err
                 }
+                lookupErr = err
+              }
 
-                const res = { closerPeers: peers }
+              const res = { closerPeers: peers }
 
-                if ((rec && rec.value) || (err && err.code === 'ERR_INVALID_RECORD')) {
-                  pathVals.push({
-                    val: rec && rec.value,
-                    from: peer
-                  })
-                }
+              if (lookupErr) console.log('lookupErr', lookupErr)
+              if ((rec && rec.value) || lookupErr) {
+                pathVals.push({
+                  val: rec && rec.value,
+                  from: peer
+                })
+              }
 
-                // enough is enough
-                if (pathVals.length >= pathSize) {
-                  res.pathComplete = true
-                }
+              // enough is enough
+              if (pathVals.length >= pathSize) {
+                res.pathComplete = true
+              }
 
-                cb(null, res)
-              })
+              return res
             }
           })
 
@@ -426,16 +431,12 @@ class KadDHT extends EventEmitter {
         // There is no distinction between the disjoint paths,
         // so there are no per-path variables in this scope.
         // Just return the actual query function.
-        return (peer, callback) => {
-          waterfall([
-            (cb) => this._closerPeersSingle(key, peer, cb),
-            (closer, cb) => {
-              cb(null, {
-                closerPeers: closer,
-                pathComplete: options.shallow ? true : undefined
-              })
-            }
-          ], callback)
+        return async (peer) => {
+          const closer = await this._closerPeersSingleAsync(key, peer)
+          return {
+            closerPeers: closer,
+            pathComplete: options.shallow ? true : undefined
+          }
         }
       })
 
@@ -651,25 +652,21 @@ class KadDHT extends EventEmitter {
             // There is no distinction between the disjoint paths,
             // so there are no per-path variables in this scope.
             // Just return the actual query function.
-            return (peer, cb) => {
-              waterfall([
-                (cb) => this._findPeerSingle(peer, id, cb),
-                (msg, cb) => {
-                  const match = msg.closerPeers.find((p) => p.id.isEqual(id))
+            return async (peer) => {
+              const msg = await this._findPeerSingleAsync(peer, id)
+              const match = msg.closerPeers.find((p) => p.id.isEqual(id))
 
-                  // found it
-                  if (match) {
-                    return cb(null, {
-                      peer: match,
-                      queryComplete: true
-                    })
-                  }
-
-                  cb(null, {
-                    closerPeers: msg.closerPeers
-                  })
+              // found it
+              if (match) {
+                return {
+                  peer: match,
+                  queryComplete: true
                 }
-              ], cb)
+              }
+
+              return {
+                closerPeers: msg.closerPeers
+              }
             }
           })
 

--- a/src/query/path.js
+++ b/src/query/path.js
@@ -22,8 +22,8 @@ class Path {
   constructor (run, queryFunc) {
     this.run = run
     this.queryFunc = utils.withTimeout(queryFunc, QUERY_FUNC_TIMEOUT)
-    if (!this.queryFunc) throw new Error('QF missing')
-    if (typeof this.queryFunc !== 'function') throw new Error('QF bad bad: ' + typeof this.queryFunc)
+    if (!this.queryFunc) throw new Error('Path requires a `queryFn` to be specified')
+    if (typeof this.queryFunc !== 'function') throw new Error('Path expected `queryFn` to be a function. Got ' + typeof this.queryFunc)
 
     /**
      * @type {Array<PeerId>}

--- a/src/query/path.js
+++ b/src/query/path.js
@@ -1,8 +1,7 @@
 'use strict'
 
-const timeout = require('async/timeout')
-const promisify = require('promisify-es6')
 const PeerQueue = require('../peer-queue')
+const utils = require('../utils')
 
 // TODO: Temporary until parallel dial in Switch have a proper
 // timeout. Requires async/await refactor of transports and
@@ -22,8 +21,9 @@ class Path {
    */
   constructor (run, queryFunc) {
     this.run = run
-    this.queryFunc = timeout(queryFunc, QUERY_FUNC_TIMEOUT)
-    this.queryFuncAsync = promisify(this.queryFunc)
+    this.queryFunc = utils.withTimeout(queryFunc, QUERY_FUNC_TIMEOUT)
+    if (!this.queryFunc) throw new Error('QF missing')
+    if (typeof this.queryFunc !== 'function') throw new Error('QF bad bad: ' + typeof this.queryFunc)
 
     /**
      * @type {Array<PeerId>}

--- a/src/query/workerQueue.js
+++ b/src/query/workerQueue.js
@@ -210,7 +210,7 @@ class WorkerQueue {
   async execQuery (peer) {
     let res, queryError
     try {
-      res = await this.path.queryFuncAsync(peer)
+      res = await this.path.queryFunc(peer)
     } catch (err) {
       queryError = err
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,12 +10,7 @@ const map = require('async/map')
 const Record = require('libp2p-record').Record
 const setImmediate = require('async/setImmediate')
 const PeerId = require('peer-id')
-
-class TimeoutError extends Error {
-  get code () {
-    return 'ETIMEDOUT'
-  }
-}
+const errcode = require('err-code')
 
 /**
  * Creates a DHT ID by hashing a given buffer.
@@ -217,9 +212,11 @@ exports.withTimeout = (asyncFn, time) => {
   return async (...args) => {
     return Promise.race([
       asyncFn(...args),
-      new Promise((resolve, reject) => setTimeout(() => reject(new TimeoutError()), time))
+      new Promise((resolve, reject) => {
+        setTimeout(() => {
+          reject(errcode(new Error('Async function did not complete before timeout'), 'ETIMEDOUT'))
+        }, time)
+      })
     ])
   }
 }
-
-exports.TimeoutError = TimeoutError

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -1104,7 +1104,6 @@ describe('KadDHT', () => {
           (cb) => connect(dhtA, dhtB, cb),
           (cb) => dhtA.get(Buffer.from('/v/hello'), cb)
         ], (err) => {
-          if (err) console.log(err.stack)
           expect(err).to.exist()
           expect(err.code).to.be.eql('ERR_NOT_FOUND')
 

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -302,7 +302,7 @@ describe('KadDHT', () => {
       const dhtB = dhts[1]
       const dhtC = dhts[2]
       const dhtD = dhts[3]
-      const stub = sinon.stub(dhtD, '_verifyRecordLocally').callsArgWithAsync(1, error)
+      const stub = sinon.stub(dhtD, '_verifyRecordLocallyAsync').rejects(error)
 
       waterfall([
         (cb) => connect(dhtA, dhtB, cb),
@@ -335,8 +335,8 @@ describe('KadDHT', () => {
       const dhtB = dhts[1]
       const dhtC = dhts[2]
       const dhtD = dhts[3]
-      const stub = sinon.stub(dhtD, '_verifyRecordLocally').callsArgWithAsync(1, error)
-      const stub2 = sinon.stub(dhtC, '_verifyRecordLocally').callsArgWithAsync(1, error)
+      const stub = sinon.stub(dhtD, '_verifyRecordLocallyAsync').rejects(error)
+      const stub2 = sinon.stub(dhtC, '_verifyRecordLocallyAsync').rejects(error)
 
       waterfall([
         (cb) => connect(dhtA, dhtB, cb),
@@ -370,7 +370,7 @@ describe('KadDHT', () => {
       const dhtA = dhts[0]
       const dhtB = dhts[1]
       const dhtC = dhts[2]
-      const stub = sinon.stub(dhtC, '_verifyRecordLocally').callsArgWithAsync(1, error)
+      const stub = sinon.stub(dhtC, '_verifyRecordLocallyAsync').rejects(error)
 
       waterfall([
         (cb) => connect(dhtA, dhtB, cb),
@@ -477,7 +477,7 @@ describe('KadDHT', () => {
       const dhtA = dhts[0]
       const dhtB = dhts[1]
 
-      const dhtASpy = sinon.spy(dhtA, '_putValueToPeer')
+      const dhtASpy = sinon.spy(dhtA, '_putValueToPeerAsync')
 
       series([
         (cb) => dhtA.put(Buffer.from('/v/hello'), Buffer.from('worldA'), cb),
@@ -1010,7 +1010,9 @@ describe('KadDHT', () => {
       sw.connection.addStreamMuxer(Mplex)
       sw.connection.reuse()
       const dht = new KadDHT(sw)
-      dht.start(() => {
+      dht.start((err) => {
+        expect(err).to.not.exist()
+
         const key = Buffer.from('/v/hello')
         const value = Buffer.from('world')
         const rec = new Record(key, value)
@@ -1019,9 +1021,7 @@ describe('KadDHT', () => {
           // Simulate returning a peer id to query
           sinon.stub(dht.routingTable, 'closestPeers').returns([peerInfos[1].id]),
           // Simulate going out to the network and returning the record
-          sinon.stub(dht, '_getValueOrPeers').callsFake((peer, k, cb) => {
-            cb(null, rec)
-          })
+          sinon.stub(dht, '_getValueOrPeersAsync').callsFake(async () => ({ record: rec }))
         ]
 
         dht.getMany(key, 1, (err, res) => {
@@ -1070,7 +1070,7 @@ describe('KadDHT', () => {
 
         const dhtA = dhts[0]
         const dhtB = dhts[1]
-        const stub = sinon.stub(dhtA, '_getValueOrPeers').callsArgWithAsync(2, error)
+        const stub = sinon.stub(dhtA, '_getValueOrPeersAsync').rejects(error)
 
         waterfall([
           (cb) => connect(dhtA, dhtB, cb),
@@ -1098,12 +1098,13 @@ describe('KadDHT', () => {
 
         const dhtA = dhts[0]
         const dhtB = dhts[1]
-        const stub = sinon.stub(dhtA, '_getValueOrPeers').callsArgWithAsync(2, error)
+        const stub = sinon.stub(dhtA, '_getValueOrPeersAsync').rejects(error)
 
         waterfall([
           (cb) => connect(dhtA, dhtB, cb),
           (cb) => dhtA.get(Buffer.from('/v/hello'), cb)
         ], (err) => {
+          if (err) console.log(err.stack)
           expect(err).to.exist()
           expect(err.code).to.be.eql('ERR_NOT_FOUND')
 

--- a/test/kad-utils.spec.js
+++ b/test/kad-utils.spec.js
@@ -39,6 +39,22 @@ describe('kad utils', () => {
     })
   })
 
+  describe('withTimeout', () => {
+    it('rejects with the error in the original function', async () => {
+      const original = async () => { throw new Error('explode') }
+      const asyncFn = utils.withTimeout(original, 100)
+      let err
+      try {
+        await asyncFn()
+      } catch (_err) {
+        err = _err
+      }
+
+      expect(err).to.exist()
+      expect(err.message).to.include('explode')
+    })
+  })
+
   describe('sortClosestPeers', () => {
     it('sorts a list of PeerInfos', (done) => {
       const rawIds = [

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -57,7 +57,7 @@ describe('Query', () => {
     dht.switch.dial = (peer, callback) => callback()
 
     let i = 0
-    const query = async (p) => {
+    const queryFunc = async (p) => {
       if (i++ === 1) {
         expect(p.id).to.eql(peerInfos[2].id.id)
 
@@ -72,7 +72,7 @@ describe('Query', () => {
       }
     }
 
-    const q = new Query(dht, peer.id.id, () => query)
+    const q = new Query(dht, peer.id.id, () => queryFunc)
     promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
       expect(err).to.not.exist()
       expect(res.paths[0].value).to.eql(Buffer.from('cool'))
@@ -90,7 +90,7 @@ describe('Query', () => {
 
     let i = 0
     const visited = []
-    const query = async (p) => {
+    const queryFunc = async (p) => {
       visited.push(p)
 
       if (i++ === 1) {
@@ -102,7 +102,7 @@ describe('Query', () => {
       }
     }
 
-    const q = new Query(dht, peer.id.id, () => query)
+    const q = new Query(dht, peer.id.id, () => queryFunc)
     promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
       expect(err).not.to.exist()
 
@@ -126,9 +126,9 @@ describe('Query', () => {
     // mock this so we can dial non existing peers
     dht.switch.dial = (peer, callback) => callback()
 
-    const query = async (p) => { throw new Error('fail') }
+    const queryFunc = async (p) => { throw new Error('fail') }
 
-    const q = new Query(dht, peer.id.id, () => query)
+    const q = new Query(dht, peer.id.id, () => queryFunc)
     promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
       expect(err).to.exist()
       expect(err.message).to.eql('fail')
@@ -139,9 +139,9 @@ describe('Query', () => {
   it('returns empty run if initial peer list is empty', (done) => {
     const peer = peerInfos[0]
 
-    const query = async (p) => {}
+    const queryFunc = async (p) => {}
 
-    const q = new Query(dht, peer.id.id, () => query)
+    const q = new Query(dht, peer.id.id, () => queryFunc)
     promiseToCallback(q.run([]))((err, res) => {
       expect(err).to.not.exist()
 
@@ -159,13 +159,13 @@ describe('Query', () => {
     // mock this so we can dial non existing peers
     dht.switch.dial = (peer, callback) => callback()
 
-    const query = async (p) => {
+    const queryFunc = async (p) => {
       return {
         closerPeers: [peerInfos[2]]
       }
     }
 
-    const q = new Query(dht, peer.id.id, () => query)
+    const q = new Query(dht, peer.id.id, () => queryFunc)
     promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
       expect(err).to.not.exist()
       expect(res.finalSet.size).to.eql(2)
@@ -207,14 +207,14 @@ describe('Query', () => {
       ]
     }
 
-    const query = async (p) => {
+    const queryFunc = async (p) => {
       const closer = topology[p.toB58String()]
       return {
         closerPeers: closer || []
       }
     }
 
-    const q = new Query(dht, peer.id.id, () => query)
+    const q = new Query(dht, peer.id.id, () => queryFunc)
     promiseToCallback(q.run([peerInfos[1].id, peerInfos[2].id, peerInfos[3].id]))((err, res) => {
       expect(err).to.not.exist()
 
@@ -246,7 +246,7 @@ describe('Query', () => {
       }
     }
 
-    const query = (p) => {
+    const queryFunc = async (p) => {
       const res = topology[p.toB58String()] || {}
       return {
         closerPeers: res.closer || [],
@@ -255,7 +255,7 @@ describe('Query', () => {
       }
     }
 
-    const q = new Query(dht, peer.id.id, () => query)
+    const q = new Query(dht, peer.id.id, () => queryFunc)
     promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
       expect(err).to.not.exist()
 
@@ -353,14 +353,14 @@ describe('Query', () => {
         }
       }
 
-      const query = async (p) => {
+      const queryFunc = async (p) => {
         const res = topology[p.toB58String()] || {}
         return {
           closerPeers: res.closer || []
         }
       }
 
-      const q = new Query(dhtA, peer.id.id, () => query)
+      const q = new Query(dhtA, peer.id.id, () => queryFunc)
 
       dhtA.stop(() => {
         promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
@@ -410,7 +410,7 @@ describe('Query', () => {
       }
     }
 
-    const query = async (p) => {
+    const queryFunc = async (p) => {
       const res = topology[p.toB58String()] || {}
       await new Promise(resolve => setTimeout(resolve, res.delay))
       return {
@@ -420,7 +420,7 @@ describe('Query', () => {
       }
     }
 
-    const q = new Query(dht, peer.id.id, () => query)
+    const q = new Query(dht, peer.id.id, () => queryFunc)
     promiseToCallback(q.run([peerInfos[1].id, peerInfos[4].id]))((err, res) => {
       expect(err).to.not.exist()
 
@@ -475,7 +475,7 @@ describe('Query', () => {
     }
 
     const visited = []
-    const query = async (p) => {
+    const queryFunc = async (p) => {
       visited.push(p)
 
       const res = topology[p.toB58String()] || {}
@@ -488,7 +488,7 @@ describe('Query', () => {
       }
     }
 
-    const q = new Query(dht, peer.id.id, () => query)
+    const q = new Query(dht, peer.id.id, () => queryFunc)
     promiseToCallback(q.run([peerInfos[1].id, peerInfos[4].id]))((err, res) => {
       expect(err).to.not.exist()
 
@@ -551,7 +551,7 @@ describe('Query', () => {
     }
 
     const visited = []
-    const query = async (p) => {
+    const queryFunc = async (p) => {
       visited.push(p)
 
       const res = topology[p.toB58String()] || {}
@@ -566,7 +566,7 @@ describe('Query', () => {
       }
     }
 
-    const q = new Query(dht, peer.id.id, () => query)
+    const q = new Query(dht, peer.id.id, () => queryFunc)
     promiseToCallback(q.run([peerInfos[1].id, peerInfos[4].id]))((err, res) => {
       expect(err).to.not.exist()
 
@@ -639,7 +639,7 @@ describe('Query', () => {
         const peerIdToInfo = (peerId) => peerInfos.find(pi => pi.id === peerId)
 
         const visited = []
-        const query = async (peerId) => {
+        const queryFunc = async (peerId) => {
           visited.push(peerId)
           const i = peerIndex(peerId)
           const closerIndexes = topology[i] || []
@@ -647,7 +647,7 @@ describe('Query', () => {
           return { closerPeers }
         }
 
-        const q = new Query(dht, peerInfos[0].id.id, () => query)
+        const q = new Query(dht, peerInfos[0].id.id, () => queryFunc)
         promiseToCallback(q.run(initial))((err, res) => {
           expect(err).to.not.exist()
 
@@ -741,13 +741,13 @@ describe('Query', () => {
     // mock this so we can dial non existing peers
     dht.switch.dial = (peer, callback) => callback()
 
-    const query = async (p) => {
+    const queryFunc = async (p) => {
       return {
         closerPeers: [peerInfos[2]]
       }
     }
 
-    const q = new Query(dht, peer.id.id, () => query)
+    const q = new Query(dht, peer.id.id, () => queryFunc)
     promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
       expect(err).to.not.exist()
     })

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -8,8 +8,8 @@ const PeerBook = require('peer-book')
 const Switch = require('libp2p-switch')
 const TCP = require('libp2p-tcp')
 const Mplex = require('libp2p-mplex')
-const setImmediate = require('async/setImmediate')
 const promiseToCallback = require('promise-to-callback')
+const promisify = require('promisify-es6')
 
 const DHT = require('../src')
 const Query = require('../src/query')
@@ -57,19 +57,19 @@ describe('Query', () => {
     dht.switch.dial = (peer, callback) => callback()
 
     let i = 0
-    const query = (p, cb) => {
+    const query = async (p) => {
       if (i++ === 1) {
         expect(p.id).to.eql(peerInfos[2].id.id)
 
-        return cb(null, {
+        return {
           value: Buffer.from('cool'),
           pathComplete: true
-        })
+        }
       }
       expect(p.id).to.eql(peerInfos[1].id.id)
-      cb(null, {
+      return {
         closerPeers: [peerInfos[2]]
-      })
+      }
     }
 
     const q = new Query(dht, peer.id.id, () => query)
@@ -90,16 +90,16 @@ describe('Query', () => {
 
     let i = 0
     const visited = []
-    const query = (p, cb) => {
+    const query = async (p) => {
       visited.push(p)
 
       if (i++ === 1) {
-        return cb(new Error('fail'))
+        throw new Error('fail')
       }
 
-      cb(null, {
+      return {
         closerPeers: [peerInfos[2]]
-      })
+      }
     }
 
     const q = new Query(dht, peer.id.id, () => query)
@@ -126,7 +126,7 @@ describe('Query', () => {
     // mock this so we can dial non existing peers
     dht.switch.dial = (peer, callback) => callback()
 
-    const query = (p, cb) => cb(new Error('fail'))
+    const query = async (p) => { throw new Error('fail') }
 
     const q = new Query(dht, peer.id.id, () => query)
     promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
@@ -139,11 +139,10 @@ describe('Query', () => {
   it('returns empty run if initial peer list is empty', (done) => {
     const peer = peerInfos[0]
 
-    const query = (p, cb) => {}
+    const query = async (p) => {}
 
     const q = new Query(dht, peer.id.id, () => query)
     promiseToCallback(q.run([]))((err, res) => {
-      if (err) console.error(err)
       expect(err).to.not.exist()
 
       // Should not visit any peers
@@ -160,10 +159,10 @@ describe('Query', () => {
     // mock this so we can dial non existing peers
     dht.switch.dial = (peer, callback) => callback()
 
-    const query = (p, cb) => {
-      cb(null, {
+    const query = async (p) => {
+      return {
         closerPeers: [peerInfos[2]]
-      })
+      }
     }
 
     const q = new Query(dht, peer.id.id, () => query)
@@ -208,11 +207,11 @@ describe('Query', () => {
       ]
     }
 
-    const query = (p, cb) => {
+    const query = async (p) => {
       const closer = topology[p.toB58String()]
-      cb(null, {
+      return {
         closerPeers: closer || []
-      })
+      }
     }
 
     const q = new Query(dht, peer.id.id, () => query)
@@ -247,13 +246,13 @@ describe('Query', () => {
       }
     }
 
-    const query = (p, cb) => {
+    const query = (p) => {
       const res = topology[p.toB58String()] || {}
-      cb(null, {
+      return {
         closerPeers: res.closer || [],
         value: res.value,
         pathComplete: res.pathComplete
-      })
+      }
     }
 
     const q = new Query(dht, peer.id.id, () => query)
@@ -297,26 +296,29 @@ describe('Query', () => {
       }
 
       const visited = []
-      const query = (p, cb) => {
+      const queryFunc = async (p) => {
         visited.push(p)
 
-        const invokeCb = () => {
+        const getResult = async () => {
           const res = topology[p.toB58String()] || {}
-          cb(null, {
+          // this timeout is necesary so `dhtA.stop` has time to stop the
+          // requests before they all complete
+          await new Promise(resolve => setTimeout(resolve, 100))
+          return {
             closerPeers: res.closer || []
-          })
+          }
         }
 
         // Shut down after visiting peerInfos[2]
         if (p.toB58String() === peerInfos[2].id.toB58String()) {
-          dhtA.stop(invokeCb)
+          await promisify(cb => dhtA.stop(cb))
           setTimeout(checkExpectations, 100)
-        } else {
-          invokeCb()
+          return getResult()
         }
+        return getResult()
       }
 
-      const q = new Query(dhtA, peer.id.id, () => query)
+      const q = new Query(dhtA, peer.id.id, () => queryFunc)
       promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
         expect(err).to.not.exist()
       })
@@ -351,11 +353,11 @@ describe('Query', () => {
         }
       }
 
-      const query = (p, cb) => {
+      const query = async (p) => {
         const res = topology[p.toB58String()] || {}
-        cb(null, {
+        return {
           closerPeers: res.closer || []
-        })
+        }
       }
 
       const q = new Query(dhtA, peer.id.id, () => query)
@@ -408,15 +410,14 @@ describe('Query', () => {
       }
     }
 
-    const query = (p, cb) => {
+    const query = async (p) => {
       const res = topology[p.toB58String()] || {}
-      setTimeout(() => {
-        cb(null, {
-          closerPeers: res.closer || [],
-          value: res.value,
-          pathComplete: res.pathComplete
-        })
-      }, res.delay)
+      await new Promise(resolve => setTimeout(resolve, res.delay))
+      return {
+        closerPeers: res.closer || [],
+        value: res.value,
+        pathComplete: res.pathComplete
+      }
     }
 
     const q = new Query(dht, peer.id.id, () => query)
@@ -474,18 +475,17 @@ describe('Query', () => {
     }
 
     const visited = []
-    const query = (p, cb) => {
+    const query = async (p) => {
       visited.push(p)
 
       const res = topology[p.toB58String()] || {}
-      setTimeout(() => {
-        cb(null, {
-          closerPeers: res.closer || [],
-          value: res.value,
-          pathComplete: res.pathComplete,
-          queryComplete: res.queryComplete
-        })
-      }, res.delay)
+      await new Promise(resolve => setTimeout(resolve, res.delay))
+      return {
+        closerPeers: res.closer || [],
+        value: res.value,
+        pathComplete: res.pathComplete,
+        queryComplete: res.queryComplete
+      }
     }
 
     const q = new Query(dht, peer.id.id, () => query)
@@ -551,20 +551,19 @@ describe('Query', () => {
     }
 
     const visited = []
-    const query = (p, cb) => {
+    const query = async (p) => {
       visited.push(p)
 
       const res = topology[p.toB58String()] || {}
-      setTimeout(() => {
-        if (res.error) {
-          return cb(new Error('path error'))
-        }
-        cb(null, {
-          closerPeers: res.closer || [],
-          value: res.value,
-          pathComplete: res.pathComplete
-        })
-      }, res.delay)
+      await new Promise(resolve => setTimeout(resolve, res.delay))
+      if (res.error) {
+        throw new Error('path error')
+      }
+      return {
+        closerPeers: res.closer || [],
+        value: res.value,
+        pathComplete: res.pathComplete
+      }
     }
 
     const q = new Query(dht, peer.id.id, () => query)
@@ -640,12 +639,12 @@ describe('Query', () => {
         const peerIdToInfo = (peerId) => peerInfos.find(pi => pi.id === peerId)
 
         const visited = []
-        const query = (peerId, cb) => {
+        const query = async (peerId) => {
           visited.push(peerId)
           const i = peerIndex(peerId)
           const closerIndexes = topology[i] || []
           const closerPeers = closerIndexes.map(j => peerIdToInfo(sorted[j]))
-          setTimeout(() => cb(null, { closerPeers }))
+          return { closerPeers }
         }
 
         const q = new Query(dht, peerInfos[0].id.id, () => query)
@@ -707,7 +706,7 @@ describe('Query', () => {
       let targetVisited = false
 
       const q = new Query(dht, targetId, (trackNum) => {
-        return (p, cb) => {
+        return async (p) => {
           const response = getResponse(p, trackNum)
           expect(response).to.exist() // or we aren't on the right track
           if (response.end && !response.pathComplete) {
@@ -717,7 +716,7 @@ describe('Query', () => {
             targetVisited = true
             expect(badEndVisited).to.eql(false)
           }
-          setImmediate(() => cb(null, response))
+          return response
         }
       })
       q.concurrency = 1
@@ -742,10 +741,10 @@ describe('Query', () => {
     // mock this so we can dial non existing peers
     dht.switch.dial = (peer, callback) => callback()
 
-    const query = (p, cb) => {
-      cb(null, {
+    const query = async (p) => {
+      return {
         closerPeers: [peerInfos[2]]
-      })
+      }
     }
 
     const q = new Query(dht, peer.id.id, () => query)

--- a/test/query/index.spec.js
+++ b/test/query/index.spec.js
@@ -98,7 +98,6 @@ describe('Query', () => {
 
           // Run the 4 paths
           promiseToCallback(run.executePaths(paths))((err) => {
-            if (err) console.log(err.stack)
             expect(err).to.not.exist()
             // The resulting peers should all be from path 0 as it had the closest
             expect(run.peersQueried.peers).to.eql(paths[0].initialPeers)

--- a/test/query/index.spec.js
+++ b/test/query/index.spec.js
@@ -67,7 +67,7 @@ describe('Query', () => {
       const PATHS = 5
       sinon.stub(dht, 'disjointPaths').value(PATHS)
       sinon.stub(dht._queryManager, 'running').value(true)
-      let querySpy = sinon.stub().callsArgWith(1, null, {})
+      const querySpy = sinon.stub().resolves({})
 
       let query = new Query(dht, targetKey.key, () => querySpy)
 
@@ -98,6 +98,7 @@ describe('Query', () => {
 
           // Run the 4 paths
           promiseToCallback(run.executePaths(paths))((err) => {
+            if (err) console.log(err.stack)
             expect(err).to.not.exist()
             // The resulting peers should all be from path 0 as it had the closest
             expect(run.peersQueried.peers).to.eql(paths[0].initialPeers)
@@ -122,7 +123,7 @@ describe('Query', () => {
       sinon.stub(dht, 'disjointPaths').value(1)
       sinon.stub(dht._queryManager, 'running').value(true)
 
-      let querySpy = sinon.stub().callsArgWith(1, null, {})
+      const querySpy = sinon.stub().resolves({})
       let query = new Query(dht, targetKey.key, () => querySpy)
 
       let run = new Run(query)
@@ -147,8 +148,11 @@ describe('Query', () => {
         const returnPeers = sortedPeers.slice(16, 20)
         // When the second query happens, which is a further peer,
         // return peers 16 - 19
-        querySpy.onCall(1).callsFake((_, cb) => {
-          setTimeout(() => cb(null, { closerPeers: returnPeers }), 10)
+        querySpy.onCall(1).callsFake(async () => {
+          // this timeout ensures the queries finish in serial
+          // see https://github.com/libp2p/js-libp2p-kad-dht/pull/121#discussion_r286437978
+          await new Promise(resolve => setTimeout(resolve, 10))
+          return { closerPeers: returnPeers }
         })
 
         each(queriedPeers, (peerId, cb) => {

--- a/test/random-walk.spec.js
+++ b/test/random-walk.spec.js
@@ -21,11 +21,7 @@ describe('Random Walk', () => {
   }
 
   afterEach(() => {
-    try {
-      sinon.restore()
-    } catch (err) {
-      console.error('sinon.restore error', err)
-    }
+    sinon.restore()
   })
 
   describe('configuration', () => {

--- a/test/random-walk.spec.js
+++ b/test/random-walk.spec.js
@@ -21,7 +21,11 @@ describe('Random Walk', () => {
   }
 
   afterEach(() => {
-    sinon.restore()
+    try {
+      sinon.restore()
+    } catch (err) {
+      console.error('sinon.restore error', err)
+    }
   })
 
   describe('configuration', () => {


### PR DESCRIPTION
This refactor changes the `queryFn`s to be async. The `makePath` functions are still synchronous

```js
const q = new Query(dht, peer.id.id, () => {
  // makePath: do once-per-path setup
  return async () => {
    // queryFn: do actual query
  }
})
```

No behavioral changes were intended, but some tests needed timeouts added to their query functions in order to resolve as expected

related #82