### PR TITLE
Async Refactor: providers

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,4 +1,4 @@
 module.exports = {
-    bundlesize: { maxSize: '197kB' }
+    bundlesize: { maxSize: '222kB' }
 }
   

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "merge-options": "^1.0.1",
     "multihashes": "~0.4.14",
     "multihashing-async": "~0.5.2",
+    "p-queue": "^5.0.0",
     "peer-id": "~0.12.2",
     "peer-info": "~0.15.1",
     "priorityqueue": "~0.2.1",
@@ -62,6 +63,7 @@
     "protons": "^1.0.1",
     "pull-length-prefixed": "^1.3.2",
     "pull-stream": "^3.6.9",
+    "pull-stream-to-async-iterator": "^1.0.1",
     "varint": "^5.0.0",
     "xor-distance": "^2.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -537,7 +537,7 @@ class KadDHT extends EventEmitter {
 
     const errors = []
     waterfall([
-      (cb) => this.providers.addProvider(key, this.peerInfo.id, cb),
+      (cb) => promiseToCallback(this.providers.addProvider(key, this.peerInfo.id))(err => cb(err)),
       (cb) => this.getClosestPeers(key.buffer, cb),
       (peers, cb) => {
         const msg = new Message(Message.TYPES.ADD_PROVIDER, key.buffer, 0)

--- a/src/index.js
+++ b/src/index.js
@@ -537,6 +537,7 @@ class KadDHT extends EventEmitter {
 
     const errors = []
     waterfall([
+      // TODO: refactor this in method in async and remove this wrapper
       (cb) => promiseToCallback(this.providers.addProvider(key, this.peerInfo.id))(err => cb(err)),
       (cb) => this.getClosestPeers(key.buffer, cb),
       (peers, cb) => {

--- a/src/private.js
+++ b/src/private.js
@@ -517,7 +517,7 @@ module.exports = (dht) => ({
   async _findNProvidersAsync (key, providerTimeout, n) {
     const out = new LimitedPeerList(n)
 
-    const provs = await promisify(cb => dht.providers.getProviders(key, cb))()
+    const provs = await dht.providers.getProviders(key)
 
     provs.forEach((id) => {
       let info

--- a/src/rpc/handlers/add-provider.js
+++ b/src/rpc/handlers/add-provider.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const CID = require('cids')
-const utils = require('../../utils')
 const errcode = require('err-code')
+const promiseToCallback = require('promise-to-callback')
+
+const utils = require('../../utils')
 
 module.exports = (dht) => {
   const log = utils.logger(dht.peerInfo.id, 'rpc:add-provider')
@@ -11,7 +13,7 @@ module.exports = (dht) => {
    *
    * @param {PeerInfo} peer
    * @param {Message} msg
-   * @param {function(Error, Message)} callback
+   * @param {function(Error)} callback
    * @returns {undefined}
    */
   return function addProvider (peer, msg, callback) {
@@ -48,7 +50,7 @@ module.exports = (dht) => {
       if (!dht._isSelf(pi.id)) {
         foundProvider = true
         dht.peerBook.put(pi)
-        dht.providers.addProvider(cid, pi.id, callback)
+        promiseToCallback(dht.providers.addProvider(cid, pi.id))(err => callback(err))
       }
     })
 
@@ -59,7 +61,7 @@ module.exports = (dht) => {
     // https://github.com/libp2p/js-libp2p-kad-dht/pull/127
     // https://github.com/libp2p/js-libp2p-kad-dht/issues/128
     if (!foundProvider) {
-      dht.providers.addProvider(cid, peer.id, callback)
+      promiseToCallback(dht.providers.addProvider(cid, peer.id))(err => callback(err))
     }
   }
 }

--- a/src/rpc/handlers/get-providers.js
+++ b/src/rpc/handlers/get-providers.js
@@ -3,7 +3,7 @@
 const CID = require('cids')
 const parallel = require('async/parallel')
 const PeerInfo = require('peer-info')
-
+const promiseToCallback = require('promise-to-callback')
 const errcode = require('err-code')
 
 const Message = require('../../message')
@@ -41,7 +41,7 @@ module.exports = (dht) => {
 
         cb(null, exists)
       }),
-      (cb) => dht.providers.getProviders(cid, cb),
+      (cb) => promiseToCallback(dht.providers.getProviders(cid))(cb),
       (cb) => dht._betterPeersToQuery(msg, peer, cb)
     ], (err, res) => {
       if (err) {

--- a/test/providers.spec.js
+++ b/test/providers.spec.js
@@ -4,125 +4,91 @@
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
+const promisify = require('promisify-es6')
 const Store = require('interface-datastore').MemoryDatastore
-const parallel = require('async/parallel')
-const waterfall = require('async/waterfall')
 const CID = require('cids')
-const multihashing = require('multihashing-async')
-const map = require('async/map')
-const timesSeries = require('async/timesSeries')
-const each = require('async/each')
-const eachSeries = require('async/eachSeries')
-const range = require('lodash.range')
 const LevelStore = require('datastore-level')
 const path = require('path')
 const os = require('os')
+const multihashing = promisify(require('multihashing-async'))
 
 const Providers = require('../src/providers')
 
-const createPeerInfo = require('./utils/create-peer-info')
-const createValues = require('./utils/create-values')
+const createPeerInfo = promisify(require('./utils/create-peer-info'))
+const createValues = promisify(require('./utils/create-values'))
 
 describe('Providers', () => {
   let infos
 
-  before(function (done) {
+  before(async function () {
     this.timeout(10 * 1000)
-    createPeerInfo(3, (err, peers) => {
-      if (err) {
-        return done(err)
-      }
-
-      infos = peers
-      done()
-    })
+    infos = await createPeerInfo(3)
   })
 
-  it('simple add and get of providers', (done) => {
+  it('simple add and get of providers', async () => {
     const providers = new Providers(new Store(), infos[2].id)
 
     const cid = new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
 
-    parallel([
-      (cb) => providers.addProvider(cid, infos[0].id, cb),
-      (cb) => providers.addProvider(cid, infos[1].id, cb)
-    ], (err) => {
-      expect(err).to.not.exist()
-      providers.getProviders(cid, (err, provs) => {
-        expect(err).to.not.exist()
-        expect(provs).to.be.eql([infos[0].id, infos[1].id])
-        providers.stop()
+    await Promise.all([
+      providers.addProvider(cid, infos[0].id),
+      providers.addProvider(cid, infos[1].id)
+    ])
 
-        done()
-      })
-    })
+    const provs = await providers.getProviders(cid)
+    const ids = new Set(provs.map((peerId) => peerId.toB58String()))
+    expect(ids.has(infos[0].id.toB58String())).to.be.eql(true)
+    expect(ids.has(infos[1].id.toB58String())).to.be.eql(true)
+
+    providers.stop()
   })
 
-  it('more providers than space in the lru cache', (done) => {
+  it('more providers than space in the lru cache', async () => {
     const providers = new Providers(new Store(), infos[2].id, 10)
 
-    waterfall([
-      (cb) => map(
-        range(100),
-        (i, cb) => multihashing(Buffer.from(`hello ${i}`), 'sha2-256', cb),
-        cb
-      ),
-      (hashes, cb) => {
-        const cids = hashes.map((h) => new CID(h))
+    const hashes = await Promise.all([...new Array(100)].map((i) => {
+      return multihashing(Buffer.from(`hello ${i}`), 'sha2-256')
+    }))
 
-        map(cids, (cid, cb) => {
-          providers.addProvider(cid, infos[0].id, cb)
-        }, (err) => cb(err, cids))
-      },
-      (cids, cb) => {
-        map(cids, (cid, cb) => {
-          providers.getProviders(cid, cb)
-        }, (err, provs) => {
-          expect(err).to.not.exist()
-          expect(provs).to.have.length(100)
-          provs.forEach((p) => {
-            expect(p[0].id).to.be.eql(infos[0].id.id)
-          })
-          providers.stop()
-          cb()
-        })
-      }
-    ], done)
+    const cids = hashes.map((h) => new CID(h))
+
+    await Promise.all(cids.map(cid => providers.addProvider(cid, infos[0].id)))
+    const provs = await Promise.all(cids.map(cid => providers.getProviders(cid)))
+
+    expect(provs).to.have.length(100)
+    for (const p of provs) {
+      expect(p[0].id).to.be.eql(infos[0].id.id)
+    }
+
+    providers.stop()
   })
 
-  it('expires', (done) => {
+  it('expires', async () => {
     const providers = new Providers(new Store(), infos[2].id)
     providers.cleanupInterval = 100
     providers.provideValidity = 200
 
     const cid = new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
-    parallel([
-      (cb) => providers.addProvider(cid, infos[0].id, cb),
-      (cb) => providers.addProvider(cid, infos[1].id, cb)
-    ], (err) => {
-      expect(err).to.not.exist()
+    await Promise.all([
+      providers.addProvider(cid, infos[0].id),
+      providers.addProvider(cid, infos[1].id)
+    ])
 
-      providers.getProviders(cid, (err, provs) => {
-        expect(err).to.not.exist()
-        expect(provs).to.have.length(2)
-        expect(provs[0].id).to.be.eql(infos[0].id.id)
-        expect(provs[1].id).to.be.eql(infos[1].id.id)
-      })
+    const provs = await providers.getProviders(cid)
 
-      setTimeout(() => {
-        providers.getProviders(cid, (err, provs) => {
-          expect(err).to.not.exist()
-          expect(provs).to.have.length(0)
-          providers.stop()
-          done()
-        })
-        // TODO: this is a timeout based check, make cleanup monitorable
-      }, 400)
-    })
+    expect(provs).to.have.length(2)
+    expect(provs[0].id).to.be.eql(infos[0].id.id)
+    expect(provs[1].id).to.be.eql(infos[1].id.id)
+
+    await new Promise(resolve => setTimeout(resolve, 400))
+
+    const provsAfter = await providers.getProviders(cid)
+    expect(provsAfter).to.have.length(0)
+    providers.stop()
   })
 
   // slooow so only run when you need to
-  it.skip('many', (done) => {
+  it.skip('many', async function () {
     const p = path.join(
       os.tmpdir(), (Math.random() * 100).toString()
     )
@@ -130,39 +96,33 @@ describe('Providers', () => {
     const providers = new Providers(store, infos[2].id, 10)
 
     console.log('starting')
-    waterfall([
-      (cb) => parallel([
-        (cb) => createValues(100, cb),
-        (cb) => createPeerInfo(600, cb)
-      ], cb),
-      (res, cb) => {
-        console.log('got values and peers')
-        const values = res[0]
-        const peers = res[1]
-        let total = Date.now()
-        eachSeries(values, (v, cb) => {
-          eachSeries(peers, (p, cb) => {
-            providers.addProvider(v.cid, p.id, cb)
-          }, cb)
-        }, (err) => {
-          console.log('addProvider %s peers %s cids in %sms', peers.length, values.length, Date.now() - total)
-          expect(err).to.not.exist()
-          console.log('starting profile with %s peers and %s cids', peers.length, values.length)
-          timesSeries(3, (i, cb) => {
-            const start = Date.now()
-            each(values, (v, cb) => {
-              providers.getProviders(v.cid, cb)
-            }, (err) => {
-              expect(err).to.not.exist()
-              console.log('query %sms', (Date.now() - start))
-              cb()
-            })
-          }, cb)
-        })
+    const res = await Promise.all([
+      createValues(100),
+      createPeerInfo(600)
+    ])
+
+    console.log('got values and peers')
+    const values = res[0]
+    const peers = res[1]
+    let total = Date.now()
+
+    for (const v of values) {
+      for (const p of peers) {
+        await providers.addProvider(v.cid, p.id)
       }
-    ], (err) => {
-      expect(err).to.not.exist()
-      store.close(done)
-    })
+    }
+
+    console.log('addProvider %s peers %s cids in %sms', peers.length, values.length, Date.now() - total)
+    console.log('starting profile with %s peers and %s cids', peers.length, values.length)
+
+    for (let i = 0; i < 3; i++) {
+      const start = Date.now()
+      for (const v of values) {
+        await providers.getProviders(v.cid)
+        console.log('query %sms', (Date.now() - start))
+      }
+    }
+
+    await store.close()
   })
 })

--- a/test/providers.spec.js
+++ b/test/providers.spec.js
@@ -43,6 +43,28 @@ describe('Providers', () => {
     providers.stop()
   })
 
+  it('duplicate add of provider is deduped', async () => {
+    const providers = new Providers(new Store(), infos[2].id)
+
+    const cid = new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
+
+    await Promise.all([
+      providers.addProvider(cid, infos[0].id),
+      providers.addProvider(cid, infos[0].id),
+      providers.addProvider(cid, infos[1].id),
+      providers.addProvider(cid, infos[1].id),
+      providers.addProvider(cid, infos[1].id)
+    ])
+
+    const provs = await providers.getProviders(cid)
+    expect(provs).to.have.length(2)
+    const ids = new Set(provs.map((peerId) => peerId.toB58String()))
+    expect(ids.has(infos[0].id.toB58String())).to.be.eql(true)
+    expect(ids.has(infos[1].id.toB58String())).to.be.eql(true)
+
+    providers.stop()
+  })
+
   it('more providers than space in the lru cache', async () => {
     const providers = new Providers(new Store(), infos[2].id, 10)
 

--- a/test/providers.spec.js
+++ b/test/providers.spec.js
@@ -19,14 +19,19 @@ const createValues = promisify(require('./utils/create-values'))
 
 describe('Providers', () => {
   let infos
+  let providers
 
   before(async function () {
     this.timeout(10 * 1000)
     infos = await createPeerInfo(3)
   })
 
+  afterEach(() => {
+    providers && providers.stop()
+  })
+
   it('simple add and get of providers', async () => {
-    const providers = new Providers(new Store(), infos[2].id)
+    providers = new Providers(new Store(), infos[2].id)
 
     const cid = new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
 
@@ -39,12 +44,10 @@ describe('Providers', () => {
     const ids = new Set(provs.map((peerId) => peerId.toB58String()))
     expect(ids.has(infos[0].id.toB58String())).to.be.eql(true)
     expect(ids.has(infos[1].id.toB58String())).to.be.eql(true)
-
-    providers.stop()
   })
 
   it('duplicate add of provider is deduped', async () => {
-    const providers = new Providers(new Store(), infos[2].id)
+    providers = new Providers(new Store(), infos[2].id)
 
     const cid = new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
 
@@ -61,12 +64,10 @@ describe('Providers', () => {
     const ids = new Set(provs.map((peerId) => peerId.toB58String()))
     expect(ids.has(infos[0].id.toB58String())).to.be.eql(true)
     expect(ids.has(infos[1].id.toB58String())).to.be.eql(true)
-
-    providers.stop()
   })
 
   it('more providers than space in the lru cache', async () => {
-    const providers = new Providers(new Store(), infos[2].id, 10)
+    providers = new Providers(new Store(), infos[2].id, 10)
 
     const hashes = await Promise.all([...new Array(100)].map((i) => {
       return multihashing(Buffer.from(`hello ${i}`), 'sha2-256')
@@ -81,12 +82,10 @@ describe('Providers', () => {
     for (const p of provs) {
       expect(p[0].id).to.be.eql(infos[0].id.id)
     }
-
-    providers.stop()
   })
 
   it('expires', async () => {
-    const providers = new Providers(new Store(), infos[2].id)
+    providers = new Providers(new Store(), infos[2].id)
     providers.cleanupInterval = 100
     providers.provideValidity = 200
 
@@ -106,7 +105,6 @@ describe('Providers', () => {
 
     const provsAfter = await providers.getProviders(cid)
     expect(provsAfter).to.have.length(0)
-    providers.stop()
   })
 
   // slooow so only run when you need to
@@ -115,7 +113,7 @@ describe('Providers', () => {
       os.tmpdir(), (Math.random() * 100).toString()
     )
     const store = new LevelStore(p)
-    const providers = new Providers(store, infos[2].id, 10)
+    providers = new Providers(store, infos[2].id, 10)
 
     console.log('starting')
     const res = await Promise.all([

--- a/test/rpc/handlers/add-provider.spec.js
+++ b/test/rpc/handlers/add-provider.spec.js
@@ -8,6 +8,7 @@ const expect = chai.expect
 const parallel = require('async/parallel')
 const waterfall = require('async/waterfall')
 const _ = require('lodash')
+const promiseToCallback = require('promise-to-callback')
 
 const Message = require('../../../src/message')
 const handler = require('../../../src/rpc/handlers/add-provider')
@@ -82,7 +83,7 @@ describe('rpc - handlers - AddProvider', () => {
 
     waterfall([
       (cb) => handler(dht)(sender, msg, cb),
-      (cb) => dht.providers.getProviders(cid, cb),
+      (cb) => promiseToCallback(dht.providers.getProviders(cid))(cb),
       (provs, cb) => {
         expect(provs).to.have.length(1)
         expect(provs[0].id).to.eql(provider.id.id)
@@ -106,7 +107,7 @@ describe('rpc - handlers - AddProvider', () => {
 
     waterfall([
       (cb) => handler(dht)(sender, msg, cb),
-      (cb) => dht.providers.getProviders(cid, cb),
+      (cb) => promiseToCallback(dht.providers.getProviders(cid))(cb),
       (provs, cb) => {
         expect(dht.peerBook.has(provider.id)).to.equal(false)
         expect(provs).to.have.length(1)

--- a/test/rpc/handlers/get-providers.spec.js
+++ b/test/rpc/handlers/get-providers.spec.js
@@ -6,6 +6,7 @@ chai.use(require('dirty-chai'))
 const expect = chai.expect
 const parallel = require('async/parallel')
 const waterfall = require('async/waterfall')
+const promiseToCallback = require('promise-to-callback')
 
 const Message = require('../../../src/message')
 const utils = require('../../../src/utils')
@@ -89,7 +90,7 @@ describe('rpc - handlers - GetProviders', () => {
 
     waterfall([
       (cb) => dht._add(closer, cb),
-      (cb) => dht.providers.addProvider(v.cid, prov, cb),
+      (cb) => promiseToCallback(dht.providers.addProvider(v.cid, prov))(err => cb(err)),
       (cb) => handler(dht)(peers[0], msg, cb)
     ], (err, response) => {
       expect(err).to.not.exist()


### PR DESCRIPTION
providers.js hasn't been touched in a while, so this is mostly directly taken from #82

Added some async/callback wrappers here and there and used `pull-stream-to-async-iterator` around  `datastore.query` as #82 originally relied on the new datastore interface

Fixes #124 