### PR TITLE
fix _findNProvidersAsync discarding search results

### DIFF
--- a/src/private.js
+++ b/src/private.js
@@ -563,7 +563,7 @@ module.exports = (dht) => ({
         promiseToCallback(query.run(peers))(cb)
       }, providerTimeout)(callback))()
     } catch (err) {
-      if (err.code !== 'ETIMEDOUT' || out.length === 0) {
+      if (err.code !== 'ETIMEDOUT') {
         throw err
       }
     } finally {
@@ -576,6 +576,10 @@ module.exports = (dht) => ({
         out.push(peer)
       })
     })
+    
+    if (out.length === 0) {
+      throw errcode(new Error('no providers found'), 'ERR_NOT_FOUND')
+    }
 
     return out.toArray()
   },

--- a/src/private.js
+++ b/src/private.js
@@ -576,7 +576,7 @@ module.exports = (dht) => ({
         out.push(peer)
       })
     })
-    
+
     if (out.length === 0) {
       throw errcode(new Error('no providers found'), 'ERR_NOT_FOUND')
     }


### PR DESCRIPTION
When `_findNProvidersAsync` times out, it ignores the search results, as it's checking the `out` array before it's actually populated.


