### PR TITLE
refactor: use async datastore

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "protons": "^1.0.1",
     "pull-length-prefixed": "^1.3.2",
     "pull-stream": "^3.6.9",
-    "pull-stream-to-async-iterator": "^1.0.1",
     "varint": "^5.0.0",
     "xor-distance": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "err-code": "^1.1.2",
     "hashlru": "^2.3.0",
     "heap": "~0.2.6",
-    "interface-datastore": "~0.6.0",
+    "interface-datastore": "~0.7.0",
     "k-bucket": "^5.0.0",
     "libp2p-crypto": "~0.16.1",
     "libp2p-record": "~0.6.2",
@@ -69,9 +69,9 @@
     "xor-distance": "^2.0.0"
   },
   "devDependencies": {
-    "aegir": "^18.2.1",
+    "aegir": "^20.0.0",
     "chai": "^4.2.0",
-    "datastore-level": "~0.10.0",
+    "datastore-level": "~0.12.1",
     "dirty-chai": "^2.0.1",
     "interface-connection": "~0.3.3",
     "libp2p-mplex": "~0.8.5",

--- a/src/private.js
+++ b/src/private.js
@@ -95,7 +95,7 @@ module.exports = (dht) => ({
     // Fetch value from ds
     let rawRecord
     try {
-      rawRecord = await promisify(cb => dht.datastore.get(dsKey, cb))()
+      rawRecord = await dht.datastore.get(dsKey)
     } catch (err) {
       if (err.code === 'ERR_NOT_FOUND') {
         return undefined
@@ -114,7 +114,7 @@ module.exports = (dht) => ({
     if (record.timeReceived == null ||
         utils.now() - record.timeReceived > c.MAX_RECORD_AGE) {
       // If record is bad delete it and return
-      await promisify(cb => dht.datastore.delete(dsKey, cb))()
+      await dht.datastore.delete(dsKey)
       return undefined
     }
 
@@ -262,7 +262,7 @@ module.exports = (dht) => ({
   },
 
   async _putLocalAsync (key, rec) {
-    await promisify(cb => dht.datastore.put(utils.bufferToKey(key), rec, cb))()
+    await dht.datastore.put(utils.bufferToKey(key), rec)
     return undefined
   },
 
@@ -366,7 +366,7 @@ module.exports = (dht) => ({
   async _getLocalAsync (key) {
     dht._log('getLocal %b', key)
 
-    const raw = await promisify(cb => dht.datastore.get(utils.bufferToKey(key), cb))()
+    const raw = await dht.datastore.get(utils.bufferToKey(key))
     dht._log('found %b in local datastore', key)
     const rec = Record.deserialize(raw)
 

--- a/src/private.js
+++ b/src/private.js
@@ -214,7 +214,7 @@ module.exports = (dht) => ({
     promiseToCallback(this._findPeerSingleAsync(peer, target))(callback)
   },
 
-  async _findPeerSingleAsync (peer, target) {
+  async _findPeerSingleAsync (peer, target) { // eslint-disable-line require-await
     dht._log('_findPeerSingle %s', peer.toB58String())
     const msg = new Message(Message.TYPES.FIND_NODE, target.id, 0)
     return promisify(callback => dht.network.sendRequest(peer, msg, callback))()
@@ -436,7 +436,7 @@ module.exports = (dht) => ({
     promiseToCallback(this._getValueSingleAsync(peer, key))(callback)
   },
 
-  async _getValueSingleAsync (peer, key) {
+  async _getValueSingleAsync (peer, key) { // eslint-disable-line require-await
     const msg = new Message(Message.TYPES.GET_VALUE, key, 0)
     return promisify(cb => dht.network.sendRequest(peer, msg, cb))()
   },
@@ -598,7 +598,7 @@ module.exports = (dht) => ({
     promiseToCallback(this._findProvidersSingleAsync(peer, key))(callback)
   },
 
-  async _findProvidersSingleAsync (peer, key) {
+  async _findProvidersSingleAsync (peer, key) { // eslint-disable-line require-await
     const msg = new Message(Message.TYPES.GET_PROVIDERS, key.buffer, 0)
     return promisify(cb => dht.network.sendRequest(peer, msg, cb))()
   }

--- a/src/providers.js
+++ b/src/providers.js
@@ -5,8 +5,6 @@ const varint = require('varint')
 const PeerId = require('peer-id')
 const Key = require('interface-datastore').Key
 const Queue = require('p-queue')
-const promisify = require('promisify-es6')
-const toIterator = require('pull-stream-to-async-iterator')
 
 const c = require('./constants')
 const utils = require('./utils')
@@ -91,7 +89,7 @@ class Providers {
 
       // Get all provider entries from the datastore
       const query = this.datastore.query({ prefix: c.PROVIDERS_KEY_PREFIX })
-      for await (const entry of toIterator(query)) {
+      for await (const entry of query) {
         try {
           // Add a delete to the batch for each expired entry
           const { cid, peerId } = parseProviderKey(entry.key)
@@ -117,7 +115,7 @@ class Providers {
 
       // Commit the deletes to the datastore
       if (deleted.size) {
-        await promisify(cb => batch.commit(cb))()
+        await batch.commit()
       }
 
       // Clear expired entries from the cache
@@ -247,7 +245,7 @@ async function writeProviderEntry (store, cid, peer, time) {
 
   const key = new Key(dsKey)
   const buffer = Buffer.from(varint.encode(time))
-  return promisify(cb => store.put(key, buffer, cb))()
+  return store.put(key, buffer)
 }
 
 /**
@@ -282,7 +280,7 @@ function parseProviderKey (key) {
 async function loadProviders (store, cid) {
   const providers = new Map()
   const query = store.query({ prefix: makeProviderKey(cid) })
-  for await (const entry of toIterator(query)) {
+  for await (const entry of query) {
     const { peerId } = parseProviderKey(entry.key)
     providers.set(peerId, readTime(entry.value))
   }

--- a/src/providers.js
+++ b/src/providers.js
@@ -180,7 +180,7 @@ class Providers {
    * @param {PeerId} provider
    * @returns {Promise}
    */
-  async addProvider (cid, provider) {
+  async addProvider (cid, provider) { // eslint-disable-line require-await
     return this.syncQueue.add(async () => {
       this._log('addProvider %s', cid.toBaseEncodedString())
       const provs = await this._getProvidersMap(cid)
@@ -201,7 +201,7 @@ class Providers {
    * @param {CID} cid
    * @returns {Promise<Array<PeerId>>}
    */
-  async getProviders (cid) {
+  async getProviders (cid) { // eslint-disable-line require-await
     return this.syncQueue.add(async () => {
       this._log('getProviders %s', cid.toBaseEncodedString())
       const provs = await this._getProvidersMap(cid)
@@ -236,7 +236,7 @@ function makeProviderKey (cid) {
  *
  * @private
  */
-async function writeProviderEntry (store, cid, peer, time) {
+async function writeProviderEntry (store, cid, peer, time) { // eslint-disable-line require-await
   const dsKey = [
     makeProviderKey(cid),
     '/',

--- a/src/query/index.js
+++ b/src/query/index.js
@@ -52,7 +52,7 @@ class Query {
    * @param {Array<PeerId>} peers
    * @returns {Promise}
    */
-  async run (peers) {
+  async run (peers) { // eslint-disable-line require-await
     if (!this.dht._queryManager.running) {
       this._log.error('Attempt to run query after shutdown')
       return { finalSet: new Set(), paths: [] }

--- a/src/rpc/handlers/get-providers.js
+++ b/src/rpc/handlers/get-providers.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const CID = require('cids')
-const parallel = require('async/parallel')
 const PeerInfo = require('peer-info')
 const promiseToCallback = require('promise-to-callback')
 const errcode = require('err-code')
@@ -17,63 +16,60 @@ module.exports = (dht) => {
    *
    * @param {PeerInfo} peer
    * @param {Message} msg
-   * @param {function(Error, Message)} callback
-   * @returns {undefined}
+   * @returns {Promise<Message>} Resolves a `Message` response
    */
-  return function getProviders (peer, msg, callback) {
+  async function getProvidersAsync (peer, msg) {
     let cid
     try {
       cid = new CID(msg.key)
     } catch (err) {
-      return callback(errcode(new Error(`Invalid CID: ${err.message}`), 'ERR_INVALID_CID'))
+      throw errcode(new Error(`Invalid CID: ${err.message}`), 'ERR_INVALID_CID')
     }
 
     log('%s', cid.toBaseEncodedString())
-
     const dsKey = utils.bufferToKey(cid.buffer)
 
-    parallel([
-      (cb) => promiseToCallback(dht.datastore.has(dsKey))((err, exists) => {
-        if (err) {
-          log.error('Failed to check datastore existence', err)
-          return cb(null, false)
-        }
+    const [has, peers, closer] = await Promise.all([
+      dht.datastore.has(dsKey),
+      dht.providers.getProviders(cid),
+      dht._betterPeersToQueryAsync(msg, peer)
+    ])
 
-        cb(null, exists)
-      }),
-      (cb) => promiseToCallback(dht.providers.getProviders(cid))(cb),
-      (cb) => dht._betterPeersToQuery(msg, peer, cb)
-    ], (err, res) => {
-      if (err) {
-        return callback(err)
-      }
-      const has = res[0]
-      const closer = res[2]
-      const providers = res[1].map((p) => {
-        if (dht.peerBook.has(p)) {
-          return dht.peerBook.get(p)
-        }
-
-        return dht.peerBook.put(new PeerInfo(p))
-      })
-
-      if (has) {
-        providers.push(dht.peerInfo)
+    const providers = peers.map((p) => {
+      if (dht.peerBook.has(p)) {
+        return dht.peerBook.get(p)
       }
 
-      const response = new Message(msg.type, msg.key, msg.clusterLevel)
-
-      if (providers.length > 0) {
-        response.providerPeers = providers
-      }
-
-      if (closer.length > 0) {
-        response.closerPeers = closer
-      }
-
-      log('got %s providers %s closerPeers', providers.length, closer.length)
-
-      callback(null, response)
+      return dht.peerBook.put(new PeerInfo(p))
     })
+
+    if (has) {
+      providers.push(dht.peerInfo)
+    }
+
+    const response = new Message(msg.type, msg.key, msg.clusterLevel)
+
+    if (providers.length > 0) {
+      response.providerPeers = providers
+    }
+
+    if (closer.length > 0) {
+      response.closerPeers = closer
+    }
+
+    log('got %s providers %s closerPeers', providers.length, closer.length)
+    return response
+  }
+
+  /**
+   * Process `GetProviders` DHT messages.
+   *
+   * @param {PeerInfo} peer
+   * @param {Message} msg
+   * @param {function(Error, Message)} callback
+   * @returns {undefined}
+   */
+  return function getProviders (peer, msg, callback) {
+    promiseToCallback(getProvidersAsync(peer, msg))(callback)
   }
 }

--- a/src/rpc/handlers/get-providers.js
+++ b/src/rpc/handlers/get-providers.js
@@ -33,7 +33,7 @@ module.exports = (dht) => {
     const dsKey = utils.bufferToKey(cid.buffer)
 
     parallel([
-      (cb) => dht.datastore.has(dsKey, (err, exists) => {
+      (cb) => promiseToCallback(dht.datastore.has(dsKey))((err, exists) => {
         if (err) {
           log.error('Failed to check datastore existence', err)
           return cb(null, false)

--- a/src/rpc/handlers/put-value.js
+++ b/src/rpc/handlers/put-value.js
@@ -2,6 +2,7 @@
 
 const utils = require('../../utils')
 const errcode = require('err-code')
+const promiseToCallback = require('promise-to-callback')
 
 module.exports = (dht) => {
   const log = utils.logger(dht.peerInfo.id, 'rpc:put-value')
@@ -37,7 +38,7 @@ module.exports = (dht) => {
 
       const key = utils.bufferToKey(record.key)
 
-      dht.datastore.put(key, record.serialize(), (err) => {
+      promiseToCallback(dht.datastore.put(key, record.serialize()))(err => {
         if (err) {
           return callback(err)
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -209,7 +209,7 @@ exports.TimeoutError = class TimeoutError extends Error {
  * @private
  */
 exports.withTimeout = (asyncFn, time) => {
-  return async (...args) => {
+  return async (...args) => { // eslint-disable-line require-await
     return Promise.race([
       asyncFn(...args),
       new Promise((resolve, reject) => {

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -955,7 +955,7 @@ describe('KadDHT', () => {
         Buffer.from('hello'),
         Buffer.from('world')
       )
-      let received = new Date()
+      const received = new Date()
       received.setDate(received.getDate() - 2)
 
       record.timeReceived = received
@@ -1023,7 +1023,7 @@ describe('KadDHT', () => {
           // Simulate returning a peer id to query
           sinon.stub(dht.routingTable, 'closestPeers').returns([peerInfos[1].id]),
           // Simulate going out to the network and returning the record
-          sinon.stub(dht, '_getValueOrPeersAsync').callsFake(async () => ({ record: rec }))
+          sinon.stub(dht, '_getValueOrPeersAsync').callsFake(async () => ({ record: rec })) // eslint-disable-line require-await
         ]
 
         dht.getMany(key, 1, (err, res) => {

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -20,7 +20,7 @@ const PeerBook = require('peer-book')
 const Switch = require('libp2p-switch')
 const TCP = require('libp2p-tcp')
 const Mplex = require('libp2p-mplex')
-
+const promiseToCallback = require('promise-to-callback')
 const errcode = require('err-code')
 
 const KadDHT = require('../src')
@@ -962,7 +962,9 @@ describe('KadDHT', () => {
 
       waterfall([
         (cb) => dht._putLocal(record.key, record.serialize(), cb),
-        (cb) => dht.datastore.get(kadUtils.bufferToKey(record.key), cb),
+        (cb) => {
+          promiseToCallback(dht.datastore.get(kadUtils.bufferToKey(record.key)))(cb)
+        },
         (lookup, cb) => {
           expect(lookup).to.exist('Record should be in the local datastore')
           cb()
@@ -972,7 +974,7 @@ describe('KadDHT', () => {
         expect(err).to.not.exist()
         expect(rec).to.not.exist('Record should have expired')
 
-        dht.datastore.get(kadUtils.bufferToKey(record.key), (err, lookup) => {
+        promiseToCallback(dht.datastore.get(kadUtils.bufferToKey(record.key)))((err, lookup) => {
           expect(err).to.exist('Should throw error for not existing')
           expect(lookup).to.not.exist('Record should be removed from datastore')
           done()

--- a/test/kad-utils.spec.js
+++ b/test/kad-utils.spec.js
@@ -41,7 +41,7 @@ describe('kad utils', () => {
 
   describe('withTimeout', () => {
     it('rejects with the error in the original function', async () => {
-      const original = async () => { throw new Error('explode') }
+      const original = async () => { throw new Error('explode') } // eslint-disable-line require-await
       const asyncFn = utils.withTimeout(original, 100)
       let err
       try {

--- a/test/providers.spec.js
+++ b/test/providers.spec.js
@@ -115,16 +115,16 @@ describe('Providers', () => {
     const store = new LevelStore(p)
     providers = new Providers(store, infos[2].id, 10)
 
-    console.log('starting')
+    console.log('starting') // eslint-disable-line no-console
     const res = await Promise.all([
       createValues(100),
       createPeerInfo(600)
     ])
 
-    console.log('got values and peers')
+    console.log('got values and peers') // eslint-disable-line no-console
     const values = res[0]
     const peers = res[1]
-    let total = Date.now()
+    const total = Date.now()
 
     for (const v of values) {
       for (const p of peers) {
@@ -132,14 +132,14 @@ describe('Providers', () => {
       }
     }
 
-    console.log('addProvider %s peers %s cids in %sms', peers.length, values.length, Date.now() - total)
-    console.log('starting profile with %s peers and %s cids', peers.length, values.length)
+    console.log('addProvider %s peers %s cids in %sms', peers.length, values.length, Date.now() - total) // eslint-disable-line no-console
+    console.log('starting profile with %s peers and %s cids', peers.length, values.length) // eslint-disable-line no-console
 
     for (let i = 0; i < 3; i++) {
       const start = Date.now()
       for (const v of values) {
         await providers.getProviders(v.cid)
-        console.log('query %sms', (Date.now() - start))
+        console.log('query %sms', (Date.now() - start)) // eslint-disable-line no-console
       }
     }
 

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -57,7 +57,7 @@ describe('Query', () => {
     dht.switch.dial = (peer, callback) => callback()
 
     let i = 0
-    const queryFunc = async (p) => {
+    const queryFunc = async (p) => { // eslint-disable-line require-await
       if (i++ === 1) {
         expect(p.id).to.eql(peerInfos[2].id.id)
 
@@ -90,7 +90,7 @@ describe('Query', () => {
 
     let i = 0
     const visited = []
-    const queryFunc = async (p) => {
+    const queryFunc = async (p) => { // eslint-disable-line require-await
       visited.push(p)
 
       if (i++ === 1) {
@@ -126,7 +126,7 @@ describe('Query', () => {
     // mock this so we can dial non existing peers
     dht.switch.dial = (peer, callback) => callback()
 
-    const queryFunc = async (p) => { throw new Error('fail') }
+    const queryFunc = async (p) => { throw new Error('fail') } // eslint-disable-line require-await
 
     const q = new Query(dht, peer.id.id, () => queryFunc)
     promiseToCallback(q.run([peerInfos[1].id]))((err, res) => {
@@ -159,7 +159,7 @@ describe('Query', () => {
     // mock this so we can dial non existing peers
     dht.switch.dial = (peer, callback) => callback()
 
-    const queryFunc = async (p) => {
+    const queryFunc = async (p) => { // eslint-disable-line require-await
       return {
         closerPeers: [peerInfos[2]]
       }
@@ -207,7 +207,7 @@ describe('Query', () => {
       ]
     }
 
-    const queryFunc = async (p) => {
+    const queryFunc = async (p) => { // eslint-disable-line require-await
       const closer = topology[p.toB58String()]
       return {
         closerPeers: closer || []
@@ -246,7 +246,7 @@ describe('Query', () => {
       }
     }
 
-    const queryFunc = async (p) => {
+    const queryFunc = async (p) => { // eslint-disable-line require-await
       const res = topology[p.toB58String()] || {}
       return {
         closerPeers: res.closer || [],
@@ -353,7 +353,7 @@ describe('Query', () => {
         }
       }
 
-      const queryFunc = async (p) => {
+      const queryFunc = async (p) => { // eslint-disable-line require-await
         const res = topology[p.toB58String()] || {}
         return {
           closerPeers: res.closer || []
@@ -639,7 +639,7 @@ describe('Query', () => {
         const peerIdToInfo = (peerId) => peerInfos.find(pi => pi.id === peerId)
 
         const visited = []
-        const queryFunc = async (peerId) => {
+        const queryFunc = async (peerId) => { // eslint-disable-line require-await
           visited.push(peerId)
           const i = peerIndex(peerId)
           const closerIndexes = topology[i] || []
@@ -706,7 +706,7 @@ describe('Query', () => {
       let targetVisited = false
 
       const q = new Query(dht, targetId, (trackNum) => {
-        return async (p) => {
+        return async (p) => { // eslint-disable-line require-await
           const response = getResponse(p, trackNum)
           expect(response).to.exist() // or we aren't on the right track
           if (response.end && !response.pathComplete) {
@@ -741,7 +741,7 @@ describe('Query', () => {
     // mock this so we can dial non existing peers
     dht.switch.dial = (peer, callback) => callback()
 
-    const queryFunc = async (p) => {
+    const queryFunc = async (p) => { // eslint-disable-line require-await
       return {
         closerPeers: [peerInfos[2]]
       }

--- a/test/query/index.spec.js
+++ b/test/query/index.spec.js
@@ -33,7 +33,7 @@ describe('Query', () => {
   })
 
   describe('get closest peers', () => {
-    let targetKey = {
+    const targetKey = {
       key: Buffer.from('A key to find'),
       dhtKey: null
     }
@@ -69,18 +69,18 @@ describe('Query', () => {
       sinon.stub(dht._queryManager, 'running').value(true)
       const querySpy = sinon.stub().resolves({})
 
-      let query = new Query(dht, targetKey.key, () => querySpy)
+      const query = new Query(dht, targetKey.key, () => querySpy)
 
-      let run = new Run(query)
+      const run = new Run(query)
       promiseToCallback(run.init())(() => {
         // Add the sorted peers into 5 paths. This will weight
         // the paths with increasingly further peers
-        let sortedPeerIds = sortedPeers.map(peerInfo => peerInfo.id)
-        let peersPerPath = sortedPeerIds.length / PATHS
-        let paths = [...new Array(PATHS)].map((_, index) => {
-          let path = new Path(run, query.makePath())
-          let start = index * peersPerPath
-          let peers = sortedPeerIds.slice(start, start + peersPerPath)
+        const sortedPeerIds = sortedPeers.map(peerInfo => peerInfo.id)
+        const peersPerPath = sortedPeerIds.length / PATHS
+        const paths = [...new Array(PATHS)].map((_, index) => {
+          const path = new Path(run, query.makePath())
+          const start = index * peersPerPath
+          const peers = sortedPeerIds.slice(start, start + peersPerPath)
           peers.forEach(p => path.addInitialPeer(p))
           return path
         })
@@ -88,7 +88,7 @@ describe('Query', () => {
         // Get the peers of the 2nd closest path, and remove the path
         // We don't want to execute it. Just add its peers to peers we've
         // already queried.
-        let queriedPeers = paths.splice(1, 1)[0].initialPeers
+        const queriedPeers = paths.splice(1, 1)[0].initialPeers
         each(queriedPeers, (peerId, cb) => {
           run.peersQueried.add(peerId, cb)
         }, (err) => {
@@ -123,22 +123,22 @@ describe('Query', () => {
       sinon.stub(dht._queryManager, 'running').value(true)
 
       const querySpy = sinon.stub().resolves({})
-      let query = new Query(dht, targetKey.key, () => querySpy)
+      const query = new Query(dht, targetKey.key, () => querySpy)
 
-      let run = new Run(query)
+      const run = new Run(query)
       promiseToCallback(run.init())(() => {
-        let sortedPeerIds = sortedPeers.map(peerInfo => peerInfo.id)
+        const sortedPeerIds = sortedPeers.map(peerInfo => peerInfo.id)
 
         // Take the top 15 peers and peers 20 - 25 to seed `run.peersQueried`
         // This leaves us with only 16 - 19 as closer peers
-        let queriedPeers = [
+        const queriedPeers = [
           ...sortedPeerIds.slice(0, 15),
           ...sortedPeerIds.slice(20, 25)
         ]
 
-        let path = new Path(run, query.makePath())
+        const path = new Path(run, query.makePath())
         // Give the path a closet peer and 15 further peers
-        let pathPeers = [
+        const pathPeers = [
           ...sortedPeerIds.slice(15, 16), // 1 closer
           ...sortedPeerIds.slice(80, 95)
         ]

--- a/test/random-walk.spec.js
+++ b/test/random-walk.spec.js
@@ -11,7 +11,7 @@ const { defaultRandomWalk } = require('../src/constants')
 const { AssertionError } = require('assert')
 
 describe('Random Walk', () => {
-  let mockDHT = {
+  const mockDHT = {
     peerInfo: {
       id: {
         toB58String: () => 'QmRLoXS3E73psYaUsma1VSbboTa2J8Z9kso1tpiGLk9WQ4'
@@ -135,7 +135,7 @@ describe('Random Walk', () => {
       })
       sinon.spy(randomWalk, '_runPeriodically')
 
-      sinon.stub(randomWalk, '_walk').callsFake(async () => {
+      sinon.stub(randomWalk, '_walk').callsFake(async () => { // eslint-disable-line require-await
         // Try to start again
         randomWalk.start()
 
@@ -174,7 +174,7 @@ describe('Random Walk', () => {
         queriesPerPeriod: 1
       }
       const randomWalk = new RandomWalk(mockDHT, options)
-      sinon.stub(randomWalk, '_walk').callsFake(async (queries, timeout) => {
+      sinon.stub(randomWalk, '_walk').callsFake(async (queries, timeout) => { // eslint-disable-line require-await
         expect(queries).to.eql(options.queriesPerPeriod)
         expect(timeout).to.eql(options.timeout)
         done()

--- a/test/rpc/handlers/get-providers.spec.js
+++ b/test/rpc/handlers/get-providers.spec.js
@@ -67,8 +67,8 @@ describe('rpc - handlers - GetProviders', () => {
     const dsKey = utils.bufferToKey(v.cid.buffer)
 
     waterfall([
-      (cb) => dht.datastore.put(dsKey, v.value, cb),
-      (cb) => handler(dht)(peers[0], msg, cb)
+      (cb) => promiseToCallback(dht.datastore.put(dsKey, v.value))(cb),
+      (_, cb) => handler(dht)(peers[0], msg, cb)
     ], (err, response) => {
       expect(err).to.not.exist()
 

--- a/test/rpc/handlers/put-value.spec.js
+++ b/test/rpc/handlers/put-value.spec.js
@@ -6,6 +6,7 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 const Record = require('libp2p-record').Record
+const promiseToCallback = require('promise-to-callback')
 
 const Message = require('../../../src/message')
 const handler = require('../../../src/rpc/handlers/put-value')
@@ -65,7 +66,7 @@ describe('rpc - handlers - PutValue', () => {
       expect(response).to.be.eql(msg)
 
       const key = utils.bufferToKey(Buffer.from('hello'))
-      dht.datastore.get(key, (err, res) => {
+      promiseToCallback(dht.datastore.get(key))((err, res) => {
         expect(err).to.not.exist()
         const rec = Record.deserialize(res)
 

--- a/test/simulation/index.js
+++ b/test/simulation/index.js
@@ -1,5 +1,7 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 6] */
+/* eslint-disable no-console */
+
 'use strict'
 const { promisify } = require('util')
 const PeerBook = require('peer-book')
@@ -47,7 +49,7 @@ let topIds // Closest 20 peerIds in the network
 
   console.log('Total Nodes=%d, Dead Nodes=%d, Max Siblings per Peer=%d', NUM_PEERS, NUM_DEAD_NODES, MAX_PEERS_KNOWN)
   console.log('Starting %d runs with concurrency %d...', RUNS, ALPHA)
-  let topRunIds = []
+  const topRunIds = []
   for (var i = 0; i < RUNS; i++) {
     const { closestPeers, runTime } = await GetClosestPeersSimulation()
     const foundIds = closestPeers.map(peerId => peerId.toB58String())
@@ -99,7 +101,7 @@ async function GetClosestPeersSimulation () {
   })
 
   // Add random peers to our table
-  let ourPeers = randomMembers(peers, randomInteger(MIN_PEERS_KNOWN, MAX_PEERS_KNOWN))
+  const ourPeers = randomMembers(peers, randomInteger(MIN_PEERS_KNOWN, MAX_PEERS_KNOWN))
   for (const peer of ourPeers) {
     await promisify((peer, callback) => dht._add(peer, callback))(peer)
   }
@@ -164,7 +166,7 @@ function createPeers (num) {
  * @returns {Network}
  */
 async function MockNetwork (peers) {
-  let network = {
+  const network = {
     peers: {}
   }
 
@@ -177,7 +179,7 @@ async function MockNetwork (peers) {
 
   // Give the remaining nodes:
   for (const peer of peers.slice(NUM_DEAD_NODES)) {
-    let netPeer = network.peers[peer.id.toB58String()] = {
+    const netPeer = network.peers[peer.id.toB58String()] = {
       // dial latency
       latency: randomInteger(LATENCY_MIN, LATENCY_MAX),
       // random sibling peers from the full list
@@ -209,7 +211,7 @@ function randomInteger (min, max) {
  * @returns {Array<any>}
  */
 function randomMembers (list, num) {
-  let randomMembers = []
+  const randomMembers = []
 
   if (list.length < num) throw new Error(`cant get random members, ${num} is less than ${list.length}`)
 


### PR DESCRIPTION
BREAKING CHANGE: This change requires datastores that comply with interface-datastore@0.7.0 or later.

This refactors internal usage of `datastore` to use the async api. I also bumped `aegir` and fixed linting. Many of the rules for `require-async` are ignored at the moment, they should be removed once the full conversion is done.

**Note:** the libp2p-record update is the last dependency needed to convert to full async/await.