### PR TITLE
Bumped p-queue to ^6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "libp2p-record": "~0.6.2",
     "multihashes": "~0.4.14",
     "multihashing-async": "~0.5.2",
-    "p-queue": "^5.0.0",
+    "p-queue": "^6.0.0",
     "p-times": "^2.1.0",
     "peer-id": "~0.12.2",
     "peer-info": "~0.15.1",

--- a/src/providers.js
+++ b/src/providers.js
@@ -4,7 +4,7 @@ const cache = require('hashlru')
 const varint = require('varint')
 const PeerId = require('peer-id')
 const Key = require('interface-datastore').Key
-const Queue = require('p-queue')
+const { default: Queue } = require('p-queue')
 
 const c = require('./constants')
 const utils = require('./utils')


### PR DESCRIPTION
## Description
`js-libp2p-kad-dht`'s dependence on `p-queue@^5.0.0` is causing issues when running IPFS from inside of Electron.

https://github.com/ipfs/js-ipfs/issues/2374

## Changes
- This bumps p-queue to `^6.0.0`

## Questions
Does this repo require me to manually bump the semver in the package.json? Or do you handle that?
