### PR TITLE
fix: stop and start not fail

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -36,9 +36,8 @@ class Network {
    */
   start () {
     if (this._running) {
-      throw errcode(new Error('Network is already running'), 'ERR_NETWORK_ALREADY_RUNNING')
+      return
     }
-
     // TODO add a way to check if switch has started or not
     if (!this.dht.isStarted) {
       throw errcode(new Error('Can not start network'), 'ERR_CANNOT_START_NETWORK')
@@ -59,7 +58,7 @@ class Network {
    */
   stop () {
     if (!this.dht.isStarted && !this.isStarted) {
-      throw errcode(new Error('Network is already stopped'), 'ERR_NETWORK_ALREADY_STOPPED')
+      return
     }
     this._running = false
     this.dht.switch.removeListener('peer-mux-established', this._onPeerConnected)

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -109,30 +109,17 @@ describe('KadDHT', () => {
       expect(dht.randomWalk.stop.calledOnce).to.equal(true) // Should be always disabled, as it can be started using the instance
     })
 
-    // TODO: not fail!
-    it('fail when already started', async () => {
+    it('should not fail when already started', async () => {
       const dht = createDHT(peerInfos[0])
 
       await dht.start()
-      try {
-        await dht.start()
-      } catch (err) {
-        expect(err).to.exist()
-        return
-      }
-      throw new Error('should fail to start when already registered')
+      await dht.start()
     })
 
-    it('should fail to stop when was not started', () => {
+    it('should not fail to stop when was not started', () => {
       const dht = createDHT(peerInfos[0])
 
-      try {
-        dht.stop()
-      } catch (err) {
-        expect(err).to.exist()
-        return
-      }
-      throw new Error('should fail to stop when was not started')
+      dht.stop()
     })
   })
 


### PR DESCRIPTION
For consistency with other `libp2p` subsystems, `dht.start` when the dht is already started and `dht.stop` when the dht is not started should not throw an error