### PR TITLE
fix: peerstore get and has param

### DIFF
--- a/src/content-routing/index.js
+++ b/src/content-routing/index.js
@@ -81,8 +81,8 @@ module.exports = (dht) => {
 
       provs.forEach((id) => {
         let info
-        if (dht.peerStore.has(id)) {
-          info = dht.peerStore.get(id)
+        if (dht.peerStore.has(id.toB58String())) {
+          info = dht.peerStore.get(id.toB58String())
         } else {
           info = dht.peerStore.put(new PeerInfo(id))
         }

--- a/src/index.js
+++ b/src/index.js
@@ -323,8 +323,8 @@ class KadDHT extends EventEmitter {
     const ids = this.routingTable.closestPeers(key, this.kBucketSize)
 
     return ids.map((p) => {
-      if (this.peerStore.has(p)) {
-        return this.peerStore.get(p)
+      if (this.peerStore.has(p.toB58String())) {
+        return this.peerStore.get(p.toB58String())
       }
       return this.peerStore.put(new PeerInfo(p))
     })

--- a/src/peer-routing/index.js
+++ b/src/peer-routing/index.js
@@ -24,11 +24,11 @@ module.exports = (dht) => {
     dht._log('findPeerLocal %s', peer.toB58String())
     const p = await dht.routingTable.find(peer)
 
-    if (!p || !dht.peerStore.has(p)) {
+    if (!p || !dht.peerStore.has(p.toB58String())) {
       return
     }
 
-    return dht.peerStore.get(p)
+    return dht.peerStore.get(p.toB58String())
   }
 
   /**
@@ -128,9 +128,9 @@ module.exports = (dht) => {
 
       // sanity check
       const match = peers.find((p) => p.isEqual(id))
-      if (match && dht.peerStore.has(id)) {
+      if (match && dht.peerStore.has(id.toB58String())) {
         dht._log('found in peerStore')
-        return dht.peerStore.get(id)
+        return dht.peerStore.get(id.toB58String())
       }
 
       // query the network
@@ -177,7 +177,7 @@ module.exports = (dht) => {
       if (!success) {
         throw errcode(new Error('No peer found'), 'ERR_NOT_FOUND')
       }
-      return dht.peerStore.get(id)
+      return dht.peerStore.get(id.toB58String())
     },
 
     /**
@@ -229,8 +229,8 @@ module.exports = (dht) => {
 
       // local check
       let info
-      if (dht.peerStore.has(peer)) {
-        info = dht.peerStore.get(peer)
+      if (dht.peerStore.has(peer.toB58String())) {
+        info = dht.peerStore.get(peer.toB58String())
 
         if (info && info.id.pubKey) {
           dht._log('getPublicKey: found local copy')

--- a/src/rpc/handlers/get-providers.js
+++ b/src/rpc/handlers/get-providers.js
@@ -35,8 +35,8 @@ module.exports = (dht) => {
     ])
 
     const providers = peers.map((p) => {
-      if (dht.peerStore.has(p)) {
-        return dht.peerStore.get(p)
+      if (dht.peerStore.has(p.toB58String())) {
+        return dht.peerStore.get(p.toB58String())
       }
 
       return dht.peerStore.put(new PeerInfo(p))

--- a/src/rpc/handlers/get-value.js
+++ b/src/rpc/handlers/get-value.js
@@ -35,8 +35,8 @@ module.exports = (dht) => {
 
       if (dht._isSelf(id)) {
         info = dht.peerInfo
-      } else if (dht.peerStore.has(id)) {
-        info = dht.peerStore.get(id)
+      } else if (dht.peerStore.has(id.toB58String())) {
+        info = dht.peerStore.get(id.toB58String())
       }
 
       if (info && info.id.pubKey) {


### PR DESCRIPTION
The new `peer-store` for `get` and `has` should receive the `b58str` and not `peer-id` as https://github.com/libp2p/js-libp2p/blob/refactor/async-await/src/peer-store/index.js#L163

This module is still using `js-peerbook` for tests (for mock peerstore) which accepts both `b58str` and `peer-id` [libp2p/js-peer-book#getpeeridlike](https://github.com/libp2p/js-peer-book#getpeeridlike), which made the tests here pass. 

Anyway, I will create an issue to create a proper mock for the tests here, so that we can deprecate `peer-book`