### PR TITLE
fix: find providers should yield when found locally

### DIFF
--- a/src/content-routing/index.js
+++ b/src/content-routing/index.js
@@ -91,7 +91,11 @@ module.exports = (dht) => {
 
       // All done
       if (out.length >= n) {
-        return out.toArray()
+        // yield values
+        for (const pInfo of out.toArray()) {
+          yield pInfo
+        }
+        return
       }
 
       // need more, query the network

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -484,6 +484,24 @@ describe('KadDHT', () => {
 
       return tdht.teardown()
     })
+
+    it('find one provider locally', async function () {
+      this.timeout(20 * 1000)
+      const val = values[0]
+      const tdht = new TestDHT()
+      const [dht] = await tdht.spawn(1)
+
+      sinon.stub(dht.providers, 'getProviders').returns([dht.peerInfo.id])
+
+      // Find provider
+      const res = await all(dht.findProviders(val.cid, { maxNumProviders: 1 }))
+
+      // find providers find all the 3 providers
+      expect(res).to.exist()
+      expect(res).to.have.length(1)
+
+      return tdht.teardown()
+    })
   })
 
   describe('peer routing', () => {

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -496,7 +496,6 @@ describe('KadDHT', () => {
       // Find provider
       const res = await all(dht.findProviders(val.cid, { maxNumProviders: 1 }))
 
-      // find providers find all the 3 providers
       expect(res).to.exist()
       expect(res).to.have.length(1)
 


### PR DESCRIPTION
If the locally known providers were enough to achieve the `maxNumProviders` option, they were not being yield, but returned