### PR TITLE
fix: get many should not fail if found locally

### DIFF
--- a/src/content-fetching/index.js
+++ b/src/content-fetching/index.js
@@ -214,7 +214,10 @@ module.exports = (dht) => {
         const errMsg = 'Failed to lookup key! No peers from routing table!'
 
         dht._log.error(errMsg)
-        throw errcode(new Error(errMsg), 'ERR_NO_PEERS_IN_ROUTING_TABLE')
+        if (vals.length === 0) {
+          throw errcode(new Error(errMsg), 'ERR_NO_PEERS_IN_ROUTING_TABLE')
+        }
+        return vals
       }
 
       // we have peers, lets do the actual query to them

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -141,6 +141,24 @@ describe('KadDHT', () => {
   })
 
   describe('content fetching', () => {
+    it('put - get same node', async function () {
+      this.timeout(10 * 1000)
+
+      const tdht = new TestDHT()
+      const key = Buffer.from('/v/hello')
+      const value = Buffer.from('world')
+
+      const [dht] = await tdht.spawn(2)
+
+      // Exchange data through the dht
+      await dht.put(key, value)
+
+      const res = await dht.get(Buffer.from('/v/hello'), { timeout: 1000 })
+      expect(res).to.eql(value)
+
+      return tdht.teardown()
+    })
+
     it('put - get', async function () {
       this.timeout(10 * 1000)
 


### PR DESCRIPTION
Currently, putting and getting data from the same node fails because teh node has no peers on the routing table.

Per the previous behaviour:

https://github.com/libp2p/js-libp2p-kad-dht/blob/v0.16.1/src/index.js#L335-L394