### PR TITLE
fix: dont use peer ids in sets

### DIFF
--- a/src/query/path.js
+++ b/src/query/path.js
@@ -73,7 +73,7 @@ class Path {
 
     // The paths must be disjoint, meaning that no two paths in the Query may
     // traverse the same peer
-    if (this.run.peersSeen.has(peer)) {
+    if (this.run.peersSeen.has(peer.toB58String())) {
       return
     }
 

--- a/src/query/workerQueue.js
+++ b/src/query/workerQueue.js
@@ -128,7 +128,7 @@ class WorkerQueue {
 
     // The paths must be disjoint, meaning that no two paths in the Query may
     // traverse the same peer
-    if (this.run.peersSeen.has(peer)) {
+    if (this.run.peersSeen.has(peer.toB58String())) {
       return
     }
 
@@ -158,10 +158,10 @@ class WorkerQueue {
     }
 
     // Check if another path has queried this peer in the mean time
-    if (this.run.peersSeen.has(peer)) {
+    if (this.run.peersSeen.has(peer.toB58String())) {
       return
     }
-    this.run.peersSeen.add(peer)
+    this.run.peersSeen.add(peer.toB58String())
 
     // Execute the query on the next peer
     this.log('queue:work')


### PR DESCRIPTION
During queries, whenever a Peer is queried directly it is added to the `peersSeen` Set, which prevents us from querying them again. The issue is that currently `peerSeen` is a Set of `PeerId`. Whenever we learn about peers from the network, the deserialized PeerIds are created as new objects, which will cause them to be added to the set even if they belong to the same peer. This fixes that by using the string of the peer id and making `peerSeen` a string Set for better equality checking.