### PR TITLE
fix: remove use of assert module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const assert = require('assert')
 const { EventEmitter } = require('events')
 const errcode = require('err-code')
 
@@ -67,7 +66,10 @@ class KadDHT extends EventEmitter {
     randomWalk = {}
   }) {
     super()
-    assert(dialer, 'libp2p-kad-dht requires an instance of Dialer')
+
+    if (!dialer) {
+      throw new Error('libp2p-kad-dht requires an instance of Dialer')
+    }
 
     /**
      * Local reference to the libp2p dialer instance

--- a/src/message/index.js
+++ b/src/message/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const assert = require('assert')
 const PeerInfo = require('peer-info')
 const PeerId = require('peer-id')
 const protons = require('protons')
@@ -21,8 +20,8 @@ class Message {
    * @param {number} level
    */
   constructor (type, key, level) {
-    if (key) {
-      assert(Buffer.isBuffer(key))
+    if (key && !Buffer.isBuffer(key)) {
+      throw new Error('Key must be a buffer')
     }
 
     this.type = type

--- a/src/random-walk.js
+++ b/src/random-walk.js
@@ -3,7 +3,6 @@
 const crypto = require('libp2p-crypto')
 const multihashing = require('multihashing-async')
 const PeerId = require('peer-id')
-const assert = require('assert')
 const AbortController = require('abort-controller')
 const errcode = require('err-code')
 const times = require('p-times')
@@ -23,7 +22,9 @@ class RandomWalk {
    * @param {DHT} options.dht
    */
   constructor (dht, options) {
-    assert(dht, 'Random Walk needs an instance of the Kademlia DHT')
+    if (!dht) {
+      throw new Error('Random Walk needs an instance of the Kademlia DHT')
+    }
 
     this._kadDHT = dht
     this._options = {

--- a/test/random-walk.spec.js
+++ b/test/random-walk.spec.js
@@ -8,7 +8,6 @@ const expect = chai.expect
 const sinon = require('sinon')
 const RandomWalk = require('../src/random-walk')
 const { defaultRandomWalk } = require('../src/constants')
-const { AssertionError } = require('assert')
 
 const TestDHT = require('./utils/test-dht')
 const {
@@ -35,7 +34,7 @@ describe('Random Walk', () => {
 
   describe('configuration', () => {
     it('should use require a dht', () => {
-      expect(() => new RandomWalk()).to.throw(AssertionError)
+      expect(() => new RandomWalk()).to.throw()
     })
 
     it('should use defaults', () => {


### PR DESCRIPTION
The polyfill is big, we can simulate it by throwing an Error and it doesn't work under React Native.