### PR TITLE
chore: use new peer store api

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
     "it-pair": "^1.0.0",
+    "libp2p": "libp2p/js-libp2p#chore/deprecate-old-peer-store-api",
     "lodash": "^4.17.11",
     "lodash.random": "^3.2.0",
     "lodash.range": "^3.2.0",
@@ -83,7 +84,6 @@
     "p-each-series": "^2.1.0",
     "p-map-series": "^2.1.0",
     "p-retry": "^4.2.0",
-    "peer-book": "~0.9.2",
     "sinon": "^9.0.0"
   },
   "contributors": [

--- a/src/content-routing/index.js
+++ b/src/content-routing/index.js
@@ -80,12 +80,7 @@ module.exports = (dht) => {
       const provs = await dht.providers.getProviders(key)
 
       provs.forEach((id) => {
-        let info
-        if (dht.peerStore.has(id)) {
-          info = dht.peerStore.get(id)
-        } else {
-          info = dht.peerStore.put(new PeerInfo(id))
-        }
+        const info = dht.peerStore.get(id) || new PeerInfo(id)
         out.push(info)
       })
 
@@ -113,7 +108,7 @@ module.exports = (dht) => {
           dht._log('(%s) found %s provider entries', dht.peerInfo.id.toB58String(), provs.length)
 
           provs.forEach((prov) => {
-            pathProviders.push(dht.peerStore.put(prov))
+            pathProviders.push(prov)
           })
 
           // hooray we have all that we want

--- a/src/index.js
+++ b/src/index.js
@@ -321,14 +321,18 @@ class KadDHT extends EventEmitter {
    */
   async _nearestPeersToQuery (msg) {
     const key = await utils.convertBuffer(msg.key)
-
     const ids = this.routingTable.closestPeers(key, this.kBucketSize)
 
     return ids.map((p) => {
-      if (this.peerStore.has(p)) {
-        return this.peerStore.get(p)
+      const peer = this.peerStore.get(p)
+      const peerInfo = new PeerInfo(p)
+
+      if (peer) {
+        peer.protocols.forEach((p) => peerInfo.protocols.add(p))
+        peer.multiaddrInfos.forEach((mi) => peerInfo.multiaddrs.add(mi.multiaddr))
       }
-      return this.peerStore.put(new PeerInfo(p))
+
+      return peerInfo
     })
   }
 

--- a/src/query/workerQueue.js
+++ b/src/query/workerQueue.js
@@ -244,7 +244,6 @@ class WorkerQueue {
         if (this.dht._isSelf(closer.id)) {
           return
         }
-        closer = this.dht.peerStore.put(closer)
         this.dht._peerDiscovered(closer)
         await this.path.addPeerToQuery(closer.id)
       }))

--- a/src/rpc/handlers/add-provider.js
+++ b/src/rpc/handlers/add-provider.js
@@ -44,7 +44,8 @@ module.exports = (dht) => {
       log('received provider %s for %s (addrs %s)', peer.id.toB58String(), cid.toBaseEncodedString(), pi.multiaddrs.toArray().map((m) => m.toString()))
 
       if (!dht._isSelf(pi.id)) {
-        dht.peerStore.put(pi)
+        // Add known address to peer store
+        dht.peerStore.addressBook.add(pi.id, pi.multiaddrs.toArray())
         return dht.providers.addProvider(cid, pi.id)
       }
     })

--- a/src/rpc/handlers/get-providers.js
+++ b/src/rpc/handlers/get-providers.js
@@ -34,13 +34,7 @@ module.exports = (dht) => {
       dht._betterPeersToQuery(msg, peer)
     ])
 
-    const providers = peers.map((p) => {
-      if (dht.peerStore.has(p)) {
-        return dht.peerStore.get(p)
-      }
-
-      return dht.peerStore.put(new PeerInfo(p))
-    })
+    const providers = peers.map((p) => new PeerInfo(p))
 
     if (has) {
       providers.push(dht.peerInfo)

--- a/src/rpc/handlers/get-value.js
+++ b/src/rpc/handlers/get-value.js
@@ -35,7 +35,7 @@ module.exports = (dht) => {
 
       if (dht._isSelf(id)) {
         info = dht.peerInfo
-      } else if (dht.peerStore.has(id)) {
+      } else {
         info = dht.peerStore.get(id)
       }
 

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -648,7 +648,7 @@ describe('KadDHT', () => {
       const dhts = await tdht.spawn(2)
 
       const ids = dhts.map((d) => d.peerInfo.id)
-      dhts[0].peerStore.put(dhts[1].peerInfo)
+      dhts[0].peerStore.addressBook.add(dhts[1].peerInfo.id, dhts[1].peerInfo.multiaddrs.toArray())
 
       const key = await dhts[0].getPublicKey(ids[1])
       expect(key).to.eql(dhts[1].peerInfo.id.pubKey)
@@ -671,7 +671,7 @@ describe('KadDHT', () => {
       await tdht.connect(dhts[0], dhts[1])
 
       // remove the pub key to be sure it is fetched
-      dhts[0].peerStore.put(dhts[1].peerInfo, true)
+      dhts[0].peerStore.addressBook.add(dhts[1].peerInfo.id, dhts[1].peerInfo.multiaddrs.toArray())
 
       const key = await dhts[0].getPublicKey(ids[1])
       expect(key.equals(dhts[1].peerInfo.id.pubKey)).to.eql(true)
@@ -694,7 +694,7 @@ describe('KadDHT', () => {
     it('_nearestPeersToQuery', async () => {
       const [dht] = await tdht.spawn(1)
 
-      dht.peerStore.put(peerInfos[1])
+      dht.peerStore.addressBook.add(peerInfos[1].id, peerInfos[1].multiaddrs.toArray())
       await dht._add(peerInfos[1])
       const res = await dht._nearestPeersToQuery({ key: 'hello' })
       expect(res).to.be.eql([peerInfos[1]])
@@ -703,8 +703,8 @@ describe('KadDHT', () => {
     it('_betterPeersToQuery', async () => {
       const [dht] = await tdht.spawn(1)
 
-      dht.peerStore.put(peerInfos[1])
-      dht.peerStore.put(peerInfos[2])
+      dht.peerStore.addressBook.add(peerInfos[1].id, peerInfos[1].multiaddrs.toArray())
+      dht.peerStore.addressBook.add(peerInfos[2].id, peerInfos[2].multiaddrs.toArray())
 
       await dht._add(peerInfos[1])
       await dht._add(peerInfos[2])
@@ -769,7 +769,7 @@ describe('KadDHT', () => {
     it('_verifyRecordLocally', async () => {
       const [dht] = await tdht.spawn(1)
 
-      dht.peerStore.put(peerInfos[1])
+      dht.peerStore.addressBook.add(peerInfos[1].id, peerInfos[1].multiaddrs.toArray())
 
       const record = new Record(
         Buffer.from('hello'),

--- a/test/query/index.spec.js
+++ b/test/query/index.spec.js
@@ -8,7 +8,7 @@ chai.use(require('chai-checkmark'))
 const expect = chai.expect
 const sinon = require('sinon')
 const delay = require('delay')
-const PeerBook = require('peer-book')
+const PeerStore = require('libp2p/src/peer-store')
 
 const Query = require('../../src/query')
 const Path = require('../../src/query/path')
@@ -46,7 +46,7 @@ describe('Query', () => {
     })
 
     before('create a dht', () => {
-      const peerStore = new PeerBook()
+      const peerStore = new PeerStore()
       dht = new DHT({
         dialer: {},
         peerStore,

--- a/test/rpc/handlers/add-provider.spec.js
+++ b/test/rpc/handlers/add-provider.spec.js
@@ -83,7 +83,7 @@ describe('rpc - handlers - AddProvider', () => {
     const bookEntry = dht.peerStore.get(provider.id)
 
     // Favour peerInfo from payload over peerInfo from sender
-    expect(bookEntry.multiaddrs.toArray()).to.eql(
+    expect(bookEntry.multiaddrInfos.map((mi) => mi.multiaddr)).to.eql(
       provider.multiaddrs.toArray()
     )
   })
@@ -100,7 +100,7 @@ describe('rpc - handlers - AddProvider', () => {
 
     const provs = await dht.providers.getProviders(cid)
 
-    expect(dht.peerStore.has(provider.id)).to.equal(false)
+    expect(dht.peerStore.get(provider.id)).to.equal(undefined)
     expect(provs).to.have.length(1)
     expect(provs[0].id).to.eql(provider.id.id)
   })

--- a/test/rpc/handlers/get-value.spec.js
+++ b/test/rpc/handlers/get-value.spec.js
@@ -87,7 +87,7 @@ describe('rpc - handlers - GetValue', () => {
 
       const msg = new Message(T, key, 0)
 
-      dht.peerStore.put(other)
+      dht.peerStore.addressBook.add(other.id, other.multiaddrs.toArray())
       await dht._add(other)
       const response = await handler(dht)(peers[0], msg)
       expect(response.record).to.exist()

--- a/test/rpc/index.spec.js
+++ b/test/rpc/index.spec.js
@@ -29,7 +29,7 @@ describe('rpc', () => {
     const defer = pDefer()
     const [dht] = await tdht.spawn(1)
 
-    dht.peerStore.put(peerInfos[1])
+    dht.peerStore.addressBook.set(peerInfos[1].id, peerInfos[1].multiaddrs.toArray())
 
     const msg = new Message(Message.TYPES.GET_VALUE, Buffer.from('hello'), 5)
 

--- a/test/simulation/index.js
+++ b/test/simulation/index.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-console */
 
 'use strict'
-const PeerBook = require('peer-book')
+const PeerStore = require('libp2p/src/peer-store')
 const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
 const multihashes = require('multihashes')
@@ -85,7 +85,7 @@ async function setup () {
 async function GetClosestPeersSimulation () {
   const dht = new DHT({
     _peerInfo: ourPeerInfo,
-    _peerBook: new PeerBook(),
+    _peerBook: new PeerStore(),
     handle: () => {},
     on: () => {}
   }, {

--- a/test/utils/test-dht.js
+++ b/test/utils/test-dht.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const PeerBook = require('peer-book')
+const PeerStore = require('libp2p/src/peer-store')
 const pRetry = require('p-retry')
 const delay = require('delay')
 
@@ -27,7 +27,7 @@ class TestDHT {
 
   async _spawnOne (index, options = {}) {
     const regRecord = {}
-    const peerStore = new PeerBook()
+    const peerStore = new PeerStore()
 
     // Disable random walk by default for more controlled testing
     options = {


### PR DESCRIPTION
In the context of the PeerStore improvements specified on [libp2p/js-libp2p#582](https://github.com/libp2p/js-libp2p/issues/582) and as a follow up of [libp2p/js-libp2p#590](https://github.com/libp2p/js-libp2p/pull/590), this PR switches `libp2p-kad-dht` usage of `peer-store` to its new API.

Moreover, there were some places where data was being added to the `peerStore` with any benefit. In some cases the data was already there and in other cases there was nothing new to add at that point.

BREAKING CHANGE: uses new peer-store api

Needs:

- [x] [libp2p/js-libp2p#590](https://github.com/libp2p/js-libp2p/pull/590)

Unblocks:

- [ ] [libp2p/js-libp2p#598](https://github.com/libp2p/js-libp2p/pull/598)