### PR TITLE
chore: peer-discovery not using peer-info

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -305,8 +305,11 @@ class KadDHT extends EventEmitter {
 
   // ----------- Discovery -----------
 
-  _peerDiscovered (peerInfo) {
-    this.emit('peer', peerInfo)
+  _peerDiscovered (peerId, multiaddrs) {
+    this.emit('peer', {
+      id: peerId,
+      multiaddrs
+    })
   }
 
   // ----------- Internals -----------

--- a/src/query/workerQueue.js
+++ b/src/query/workerQueue.js
@@ -244,7 +244,7 @@ class WorkerQueue {
         if (this.dht._isSelf(closer.id)) {
           return
         }
-        this.dht._peerDiscovered(closer)
+        this.dht._peerDiscovered(closer.id, closer.multiaddrs.toArray())
         await this.path.addPeerToQuery(closer.id)
       }))
     }


### PR DESCRIPTION
In the context of deprecating `peer-info` as described on [libp2p/js-libp2p#589](https://github.com/libp2p/js-libp2p/issues/589), this PR changes the `peer-discovery` interface to emit an object containing an `id` property and a `multiaddrs` property.

We still do not run the interface tests per #44 . 

BREAKING CHANGE: peer event emits an object with id and multiaddr instead of a peer-info

Needs:

- [x] [libp2p/js-libp2p-interfaces#41](https://github.com/libp2p/js-libp2p-interfaces/pull/41)
- [x] [libp2p/js-libp2p-kad-dht#179](https://github.com/libp2p/js-libp2p-kad-dht/pull/179) -- needs rebase