### PR TITLE
chore: rename peer-store properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
     "it-pair": "^1.0.0",
-    "libp2p": "libp2p/js-libp2p#0.28.x",
+    "libp2p": "libp2p/js-libp2p#chore/rename-peer-store-properties",
     "lodash": "^4.17.11",
     "lodash.random": "^3.2.0",
     "lodash.range": "^3.2.0",

--- a/src/content-routing/index.js
+++ b/src/content-routing/index.js
@@ -83,7 +83,7 @@ module.exports = (dht) => {
         const peerData = dht.peerStore.get(id) || {}
         out.push({
           id: peerData.id || id,
-          multiaddrs: (peerData.multiaddrInfos || []).map((mi) => mi.multiaddr)
+          multiaddrs: (peerData.addresses || []).map((address) => address.multiaddr)
         })
       })
 

--- a/src/index.js
+++ b/src/index.js
@@ -330,7 +330,7 @@ class KadDHT extends EventEmitter {
 
       return {
         id: p,
-        multiaddrs: peer ? peer.multiaddrInfos.map((mi) => mi.multiaddr) : []
+        multiaddrs: peer ? peer.addresses.map((address) => address.multiaddr) : []
       }
     })
   }

--- a/src/peer-routing/index.js
+++ b/src/peer-routing/index.js
@@ -28,7 +28,7 @@ module.exports = (dht) => {
     if (peerData) {
       return {
         id: peerData.id,
-        multiaddrs: peerData.multiaddrInfos.map((mi) => mi.multiaddr)
+        multiaddrs: peerData.addresses.map((address) => address.multiaddr)
       }
     }
   }
@@ -141,7 +141,7 @@ module.exports = (dht) => {
           dht._log('found in peerStore')
           return {
             id: peer.id,
-            multiaddrs: peer.multiaddrInfos.map((mi) => mi.multiaddr)
+            multiaddrs: peer.addresses.map((address) => address.multiaddr)
           }
         }
       }
@@ -195,7 +195,7 @@ module.exports = (dht) => {
 
       return {
         id: peerData.id,
-        multiaddrs: peerData.multiaddrInfos.map((mi) => mi.multiaddr)
+        multiaddrs: peerData.addresses.map((address) => address.multiaddr)
       }
     },
 
@@ -265,7 +265,7 @@ module.exports = (dht) => {
       }
 
       peerData.id = new PeerId(peer.id, null, pk)
-      const addrs = peerData.multiaddrInfos.map((mi) => mi.multiaddr)
+      const addrs = peerData.addresses.map((address) => address.multiaddr)
       dht.peerStore.addressBook.add(peerData.id, addrs)
 
       return pk

--- a/test/rpc/handlers/add-provider.spec.js
+++ b/test/rpc/handlers/add-provider.spec.js
@@ -85,7 +85,7 @@ describe('rpc - handlers - AddProvider', () => {
     expect(provs[0].id).to.eql(peerIds[0].id)
 
     const bookEntry = dht.peerStore.get(peerIds[0])
-    expect(bookEntry.multiaddrInfos.map((mi) => mi.multiaddr)).to.eql([ma1])
+    expect(bookEntry.addresses.map((address) => address.multiaddr)).to.eql([ma1])
   })
 
   it('fall back to sender if providers have no multiaddrs', async () => {


### PR DESCRIPTION
Per [libp2p/js-libp2p#610](https://github.com/libp2p/js-libp2p/pull/610) review, we are renaming `MultiaddrInfo` into `Address`, and `peerStore.get` return value from `PeerData` into `peer` with an `addresses` property instead of `multiaddrInfos`.

This needs:

- [ ] [libp2p/js-libp2p#613](https://github.com/libp2p/js-libp2p/pull/613) - bidirectional