### PR TITLE
chore: use keybook

### DIFF
--- a/src/peer-routing/index.js
+++ b/src/peer-routing/index.js
@@ -267,6 +267,7 @@ module.exports = (dht) => {
       peerData.id = new PeerId(peer.id, null, pk)
       const addrs = peerData.addresses.map((address) => address.multiaddr)
       dht.peerStore.addressBook.add(peerData.id, addrs)
+      dht.peerStore.keyBook.set(peerData.id, pk)
 
       return pk
     }

--- a/test/rpc/handlers/get-value.spec.js
+++ b/test/rpc/handlers/get-value.spec.js
@@ -88,6 +88,8 @@ describe('rpc - handlers - GetValue', () => {
       const msg = new Message(T, key, 0)
 
       dht.peerStore.addressBook.add(other, [])
+      dht.peerStore.keyBook.set(other, other.pubKey)
+
       await dht._add(other)
       const response = await handler(dht)(peerIds[0], msg)
       expect(response.record).to.exist()


### PR DESCRIPTION
Add peer public key to the `keyBook`. This was previously achieve by an internal `peerIds` datastructure.

Needs:

- [x] [libp2p/js-libp2p#626](https://github.com/libp2p/js-libp2p/pull/626)