### PR TITLE
fix: providers leaking resources on dht construction

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
     "it-pair": "^1.0.0",
-    "libp2p": "libp2p/js-libp2p#0.28.x",
+    "libp2p": "^0.28.0-rc.0",
     "lodash": "^4.17.11",
     "lodash.random": "^3.2.0",
     "lodash.range": "^3.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -185,6 +185,7 @@ class KadDHT extends EventEmitter {
    */
   async start () {
     this._running = true
+    this.providers.start()
     this._queryManager.start()
     await this.network.start()
 

--- a/src/providers.js
+++ b/src/providers.js
@@ -60,12 +60,9 @@ class Providers {
 
   /**
    * Start the provider cleanup service
+   * @returns {void}
    */
   start () {
-    if (this._cleaner) {
-      clearInterval(this._cleaner)
-    }
-
     this._cleaner = setInterval(
       () => this._cleanup(),
       this.cleanupInterval
@@ -74,14 +71,11 @@ class Providers {
 
   /**
    * Release any resources.
-   *
    * @returns {void}
    */
   stop () {
-    if (this._cleaner) {
-      clearInterval(this._cleaner)
-      this._cleaner = null
-    }
+    clearInterval(this._cleaner)
+    this._cleaner = null
   }
 
   /**

--- a/src/providers.js
+++ b/src/providers.js
@@ -59,6 +59,20 @@ class Providers {
   }
 
   /**
+   * Start the provider cleanup service
+   */
+  start () {
+    if (this._cleaner) {
+      clearInterval(this._cleaner)
+    }
+
+    this._cleaner = setInterval(
+      () => this._cleanup(),
+      this.cleanupInterval
+    )
+  }
+
+  /**
    * Release any resources.
    *
    * @returns {void}
@@ -153,23 +167,6 @@ class Providers {
       this.providers.set(cacheKey, provs)
     }
     return provs
-  }
-
-  get cleanupInterval () {
-    return this._cleanupInterval
-  }
-
-  set cleanupInterval (val) {
-    this._cleanupInterval = val
-
-    if (this._cleaner) {
-      clearInterval(this._cleaner)
-    }
-
-    this._cleaner = setInterval(
-      () => this._cleanup(),
-      this.cleanupInterval
-    )
   }
 
   /**

--- a/test/providers.spec.js
+++ b/test/providers.spec.js
@@ -88,6 +88,8 @@ describe('Providers', () => {
     providers.cleanupInterval = 100
     providers.provideValidity = 200
 
+    providers.start()
+
     const cid = new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
     await Promise.all([
       providers.addProvider(cid, peerIds[0]),
@@ -104,6 +106,7 @@ describe('Providers', () => {
 
     const provsAfter = await providers.getProviders(cid)
     expect(provsAfter).to.have.length(0)
+    providers.stop()
   })
 
   // slooow so only run when you need to


### PR DESCRIPTION
After debugging one `js-ipfs` example hanging, I found this leaking issue.

When `js-libp2p` is created, the `dht` will be created if enabled. When the `dht` is enabled, it will be instantiated. During the instantiation, `Providers` was also instantiated and a setter was starting a timer. If the dht was created, but not started, when a process is closing, this timer was not cleared, since the stop was also not called.