### PR TITLE
fix: check for an existing connection before using the dialer

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -120,7 +120,11 @@ class Network {
     const id = to.toB58String()
     this._log('sending to: %s', id)
 
-    const conn = await this.dht.dialer.connectToPeer(to)
+    let conn = this.dht.registrar.connectionManager.get(to)
+    if (!conn) {
+      conn = await this.dht.dialer.connectToPeer(to)
+    }
+
     const { stream } = await conn.newStream(c.PROTOCOL_DHT)
 
     return this._writeReadMessage(stream, msg.serialize())
@@ -141,7 +145,10 @@ class Network {
     const id = to.toB58String()
     this._log('sending to: %s', id)
 
-    const conn = await this.dht.dialer.connectToPeer(to)
+    let conn = this.dht.registrar.connectionManager.get(to)
+    if (!conn) {
+      conn = await this.dht.dialer.connectToPeer(to)
+    }
     const { stream } = await conn.newStream(c.PROTOCOL_DHT)
 
     return this._writeMessage(stream, msg.serialize())

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -5,30 +5,36 @@ const pRetry = require('p-retry')
 const pTimeout = require('p-timeout')
 const duplexPair = require('it-pair/duplex')
 
-const createMockRegistrar = (registrarRecord) => ({
-  handle: (multicodec, handler) => {
-    const rec = registrarRecord[multicodec] || {}
+const createMockRegistrar = (registrarRecord) => {
+  const mockRegistrar = {
+    handle: (multicodec, handler) => {
+      const rec = registrarRecord[multicodec] || {}
 
-    registrarRecord[multicodec] = {
-      ...rec,
-      handler
+      registrarRecord[multicodec] = {
+        ...rec,
+        handler
+      }
+    },
+    register: ({ multicodecs, _onConnect, _onDisconnect }) => {
+      const rec = registrarRecord[multicodecs[0]] || {}
+
+      registrarRecord[multicodecs[0]] = {
+        ...rec,
+        onConnect: _onConnect,
+        onDisconnect: _onDisconnect
+      }
+
+      return multicodecs[0]
+    },
+    unregister: (id) => {
+      delete registrarRecord[id]
     }
-  },
-  register: ({ multicodecs, _onConnect, _onDisconnect }) => {
-    const rec = registrarRecord[multicodecs[0]] || {}
-
-    registrarRecord[multicodecs[0]] = {
-      ...rec,
-      onConnect: _onConnect,
-      onDisconnect: _onDisconnect
-    }
-
-    return multicodecs[0]
-  },
-  unregister: (id) => {
-    delete registrarRecord[id]
   }
-})
+  mockRegistrar.connectionManager = {
+    get: () => {}
+  }
+  return mockRegistrar
+}
 
 exports.createMockRegistrar = createMockRegistrar
 


### PR DESCRIPTION
Ideally libp2p should just get passed to the DHT and dial should be used, instead of interacting with the dialer. Currently the dialer does not check for existing connections, like libp2p.dial() does.

This issue was found at https://discuss.libp2p.io/t/random-walk-peer-discovery-adds-connections-to-same-peer/584/2. I tested the change against the sample code shared and it kept the connection count at 1 per peer.

We should probably look at updated the constructor in libp2p 0.29 to just take libp2p, instead of passing numerous components, and make that breaking change here to accompany it. We could also wait for the DHT updates before doing this.