### PR TITLE
feat: add support for client mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ class KadDHT extends EventEmitter {
    * @param {function} props.registrar.register
    * @param {function} props.registrar.unregister
    * @param {number} props.kBucketSize k-bucket size (default 20)
+   * @param {boolean} props.clientMode If true, the DHT will not respond to queries. This should be true if your node will not be dialable. (default: false)
    * @param {number} props.concurrency alpha concurrency of queries (default 3)
    * @param {Datastore} props.datastore datastore (default MemoryDatastore)
    * @param {object} props.validators validators object with namespace as keys and function(key, record, callback)
@@ -59,6 +60,7 @@ class KadDHT extends EventEmitter {
     registrar,
     datastore = new MemoryDatastore(),
     kBucketSize = c.K,
+    clientMode = false,
     concurrency = c.ALPHA,
     validators = {},
     selectors = {},
@@ -100,6 +102,8 @@ class KadDHT extends EventEmitter {
      * @type {number}
      */
     this.kBucketSize = kBucketSize
+
+    this._clientMode = clientMode
 
     /**
      * ALPHA concurrency at which each query path with run, defaults to 3

--- a/src/network.js
+++ b/src/network.js
@@ -46,8 +46,11 @@ class Network {
 
     this._running = true
 
-    // Incoming streams
-    this.dht.registrar.handle(c.PROTOCOL_DHT, this._rpc)
+    // Only respond to queries when not in client mode
+    if (this.dht._clientMode === false) {
+      // Incoming streams
+      this.dht.registrar.handle(c.PROTOCOL_DHT, this._rpc)
+    }
 
     // register protocol with topology
     const topology = new MulticodecTopology({

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -41,6 +41,10 @@ describe('KadDHT', () => {
     values = res[1]
   })
 
+  afterEach(() => {
+    sinon.restore()
+  })
+
   describe('create', () => {
     let tdht
 
@@ -106,6 +110,25 @@ describe('KadDHT', () => {
       await dht.stop()
       expect(dht.network.stop.calledOnce).to.equal(true)
       expect(dht.randomWalk.stop.calledOnce).to.equal(true)
+    })
+
+    it('server mode', async () => {
+      // Currently on by default
+      const [dht] = await tdht.spawn(1, null, false)
+      sinon.spy(dht.registrar, 'handle')
+
+      await dht.start()
+      expect(dht.registrar.handle.callCount).to.equal(1)
+      await dht.stop()
+    })
+
+    it('client mode', async () => {
+      const [dht] = await tdht.spawn(1, { clientMode: true })
+      sinon.spy(dht.registrar, 'handle')
+
+      await dht.start()
+      expect(dht.registrar.handle.callCount).to.equal(0)
+      await dht.stop()
     })
 
     it('random-walk disabled', async () => {

--- a/test/utils/test-dht.js
+++ b/test/utils/test-dht.js
@@ -18,14 +18,14 @@ class TestDHT {
     this.nodes = []
   }
 
-  spawn (length, options = {}) {
+  spawn (length, options = {}, autoStart = true) {
     return Promise.all(
       Array.from({ length })
-        .map((_, index) => this._spawnOne(index, options))
+        .map((_, index) => this._spawnOne(index, options, autoStart))
     )
   }
 
-  async _spawnOne (index, options = {}) {
+  async _spawnOne (index, options = {}, autoStart = true) {
     const regRecord = {}
     const peerStore = new PeerStore()
 
@@ -97,7 +97,9 @@ class TestDHT {
       ...options
     })
 
-    await dht.start()
+    if (autoStart) {
+      await dht.start()
+    }
 
     dht.regRecord = regRecord
     this.nodes.push(dht)


### PR DESCRIPTION
This adds the ability for DHT nodes to run in client mode. This means, nodes will not register nor respond to queries on the dht protocol, which nodes **should** be doing if they are not dialable (browser nodes, nodes behind NATs)

Ideally, this should be dynamic and should be in client mode by default, however, js-libp2p doesn't currently have autoNat support so we can't dynamically determine our dialability.

To keep this backwards compatible clientMode is disabled by default.

I left `_clientMode` as private for now. In the future we may want to add a setter to allow this to be changed dynamically.