### PR TITLE
fix: actually send the add provider rpc with addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "delay": "^4.3.0",
     "dirty-chai": "^2.0.1",
     "it-pair": "^1.0.0",
-    "libp2p": "^0.28.0",
+    "libp2p": "^0.28.5",
     "lodash": "^4.17.11",
     "lodash.random": "^3.2.0",
     "lodash.range": "^3.2.0",

--- a/src/content-routing/index.js
+++ b/src/content-routing/index.js
@@ -38,9 +38,11 @@ module.exports = (dht) => {
       // Add peer as provider
       await dht.providers.addProvider(key, dht.peerId)
 
+      const multiaddrs = dht.libp2p ? dht.libp2p.multiaddrs : []
       const msg = new Message(Message.TYPES.ADD_PROVIDER, key.buffer, 0)
       msg.providerPeers = [{
-        id: dht.peerId
+        id: dht.peerId,
+        multiaddrs
       }]
 
       // Notify closest peers

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ class KadDHT extends EventEmitter {
   /**
    * Create a new KadDHT.
    * @param {Object} props
+   * @param {Libp2p} [props.libp2p] the libp2p instance
    * @param {Dialer} props.dialer libp2p dialer instance
    * @param {PeerId} props.peerId peer's peerId
    * @param {PeerStore} props.peerStore libp2p peerStore
@@ -54,6 +55,7 @@ class KadDHT extends EventEmitter {
    * @param {randomWalkOptions} options.randomWalk randomWalk options
    */
   constructor ({
+    libp2p,
     dialer,
     peerId,
     peerStore,
@@ -71,6 +73,12 @@ class KadDHT extends EventEmitter {
     if (!dialer) {
       throw new Error('libp2p-kad-dht requires an instance of Dialer')
     }
+
+    /**
+     * Local reference to the libp2p instance. May be undefined.
+     * @type {Libp2p}
+     */
+    this.libp2p = libp2p
 
     /**
      * Local reference to the libp2p dialer instance

--- a/src/network.js
+++ b/src/network.js
@@ -5,6 +5,7 @@ const errcode = require('err-code')
 const pipe = require('it-pipe')
 const lp = require('it-length-prefixed')
 const pTimeout = require('p-timeout')
+const { consume } = require('streaming-iterables')
 
 const MulticodecTopology = require('libp2p-interfaces/src/topology/multicodec-topology')
 
@@ -186,7 +187,8 @@ class Network {
     return pipe(
       [msg],
       lp.encode(),
-      stream
+      stream,
+      consume
     )
   }
 }


### PR DESCRIPTION
I was adding some additional tests post https://github.com/libp2p/js-libp2p-kad-dht/pull/200 which exposed a couple issues with provide calls.

1. The `ADD_PROVIDER` rpc was never being sent, as no sync was set up in the pipe. This corrects that with `consume`.
1. We weren't adding our addresses to the provider record. We lost this during the peerinfo migration. `libp2p@0.28.5` includes a [patch](https://github.com/libp2p/js-libp2p/pull/700) to pass libp2p to the dht constructor to give it access. _We can simplify the constructor in a future breaking change._

The reason the tests didn't catch this is that the dht connects to and queries the provider, but they can't do this with a dht client, they need to get the provider record from another DHT server. Since the provider record wasn't actually being sent, the new tests failed.