### PR TITLE
Feature: adds custom multicodec protocol option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@
 const KadDHT = require('libp2p-kad-dht')
 ```
 
-### Usage
+## API
+
+See https://libp2p.github.io/js-libp2p-kad-dht for the auto generated docs.
+
+The libp2p-kad-dht module offers 3 APIs: Peer Routing, Content Routing and Peer Discovery.
+
+### Custom secondary DHT in libp2p
 
 ```js
 /**
@@ -55,7 +61,7 @@ function addDHT(libp2p) {
         peerId: libp2p.peerId,
         peerStore: libp2p.peerStore,
         registrar: libp2p.registrar,
-        protocol: '/custom/kad/1.0.0'
+        protocolPrefix: '/custom'
     })
     customDHT.start()
     customDHT.on('peer', libp2p._onDiscoveryPeer)
@@ -64,13 +70,6 @@ function addDHT(libp2p) {
 ```
 
 Note that you may want to supply your own peer discovery function and datastore
-
-## API
-
-See https://libp2p.github.io/js-libp2p-kad-dht for the auto generated docs.
-
-The libp2p-kad-dht module offers 3 APIs: Peer Routing, Content Routing and Peer Discovery.
-
 ### Peer Routing
 
 [![](https://raw.githubusercontent.com/libp2p/js-libp2p-interfaces/master/src/peer-routing/img/badge.png)](https://github.com/libp2p/js-libp2p-interfaces/tree/master/src/peer-routing)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,29 @@
 const KadDHT = require('libp2p-kad-dht')
 ```
 
+### Usage
+
+```js
+/**
+ * @param {Libp2p} libp2p
+ */
+function addDHT(libp2p) {
+    const customDHT = new KadDHT({
+        libp2p,
+        dialer: libp2p.dialer,
+        peerId: libp2p.peerId,
+        peerStore: libp2p.peerStore,
+        registrar: libp2p.registrar,
+        protocol: '/custom/kad/1.0.0'
+    })
+    customDHT.start()
+    customDHT.on('peer', libp2p._onDiscoveryPeer)
+    return customDHT
+}
+```
+
+Note that you may want to supply your own peer discovery function and datastore
+
 ## API
 
 See https://libp2p.github.io/js-libp2p-kad-dht for the auto generated docs.

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,7 +13,7 @@ const hour = exports.hour = 60 * minute
 
 exports.MAX_RECORD_AGE = 36 * hour
 
-exports.PROTOCOL_DHT = '/ipfs/kad/1.0.0'
+exports.PROTOCOL_DHT = '/kad/1.0.0'
 
 exports.PROVIDERS_KEY_PREFIX = '/providers/'
 

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ class KadDHT extends EventEmitter {
    * @param {function} props.registrar.register
    * @param {function} props.registrar.unregister
    * @param {string} [props.protocolPrefix = '/ipfs'] libp2p registrar handle protocol
-   * @param {string} [props.forceProtocolLegacy = false] WARNING: this is not recommended and should only be used for legacy purposes
+   * @param {boolean} [props.forceProtocolLegacy = false] WARNING: this is not recommended and should only be used for legacy purposes
    * @param {number} props.kBucketSize k-bucket size (default 20)
    * @param {boolean} props.clientMode If true, the DHT will not respond to queries. This should be true if your node will not be dialable. (default: false)
    * @param {number} props.concurrency alpha concurrency of queries (default 3)

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ class KadDHT extends EventEmitter {
    * @param {function} props.registrar.handle
    * @param {function} props.registrar.register
    * @param {function} props.registrar.unregister
+   * @param {string} props.protocol libp2p registrar handle protocol
    * @param {number} props.kBucketSize k-bucket size (default 20)
    * @param {boolean} props.clientMode If true, the DHT will not respond to queries. This should be true if your node will not be dialable. (default: false)
    * @param {number} props.concurrency alpha concurrency of queries (default 3)
@@ -63,6 +64,7 @@ class KadDHT extends EventEmitter {
     peerId,
     peerStore,
     registrar,
+    protocol = c.PROTOCOL_DHT,
     datastore = new MemoryDatastore(),
     kBucketSize = c.K,
     clientMode = false,
@@ -108,6 +110,12 @@ class KadDHT extends EventEmitter {
      * @type {Registrar}
      */
     this.registrar = registrar
+
+    /**
+     * Registrar protocol
+     * @type {string}
+     */
+    this.protocol = protocol
 
     /**
      * k-bucket size

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,8 @@ class KadDHT extends EventEmitter {
    * @param {function} props.registrar.handle
    * @param {function} props.registrar.register
    * @param {function} props.registrar.unregister
-   * @param {string} [props.protocol = c.PROTOCOL_DHT] libp2p registrar handle protocol
+   * @param {string} [props.protocolPrefix = '/ipfs'] libp2p registrar handle protocol
+   * @param {string} [props.forceProtocolLegacy = false] libp2p registrar handle protocol
    * @param {number} props.kBucketSize k-bucket size (default 20)
    * @param {boolean} props.clientMode If true, the DHT will not respond to queries. This should be true if your node will not be dialable. (default: false)
    * @param {number} props.concurrency alpha concurrency of queries (default 3)
@@ -64,7 +65,8 @@ class KadDHT extends EventEmitter {
     peerId,
     peerStore,
     registrar,
-    protocol = c.PROTOCOL_DHT,
+    protocolPrefix = '/ipfs',
+    forceProtocolLegacy = false,
     datastore = new MemoryDatastore(),
     kBucketSize = c.K,
     clientMode = false,
@@ -115,7 +117,7 @@ class KadDHT extends EventEmitter {
      * Registrar protocol
      * @type {string}
      */
-    this.protocol = protocol
+    this.protocol = protocolPrefix + (forceProtocolLegacy ? '' : c.PROTOCOL_DHT)
 
     /**
      * k-bucket size
@@ -561,4 +563,4 @@ class KadDHT extends EventEmitter {
 }
 
 module.exports = KadDHT
-module.exports.multicodec = c.PROTOCOL_DHT
+module.exports.multicodec = '/ipfs' + c.PROTOCOL_DHT

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ class KadDHT extends EventEmitter {
    * @param {function} props.registrar.register
    * @param {function} props.registrar.unregister
    * @param {string} [props.protocolPrefix = '/ipfs'] libp2p registrar handle protocol
-   * @param {string} [props.forceProtocolLegacy = false] libp2p registrar handle protocol
+   * @param {string} [props.forceProtocolLegacy = false] WARNING: this is not recommended and should only be used for legacy purposes
    * @param {number} props.kBucketSize k-bucket size (default 20)
    * @param {boolean} props.clientMode If true, the DHT will not respond to queries. This should be true if your node will not be dialable. (default: false)
    * @param {number} props.concurrency alpha concurrency of queries (default 3)

--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ class KadDHT extends EventEmitter {
    * @param {function} props.registrar.handle
    * @param {function} props.registrar.register
    * @param {function} props.registrar.unregister
-   * @param {string} props.protocol libp2p registrar handle protocol
+   * @param {string} [props.protocol = c.PROTOCOL_DHT] libp2p registrar handle protocol
    * @param {number} props.kBucketSize k-bucket size (default 20)
    * @param {boolean} props.clientMode If true, the DHT will not respond to queries. This should be true if your node will not be dialable. (default: false)
    * @param {number} props.concurrency alpha concurrency of queries (default 3)

--- a/src/network.js
+++ b/src/network.js
@@ -50,12 +50,12 @@ class Network {
     // Only respond to queries when not in client mode
     if (this.dht._clientMode === false) {
       // Incoming streams
-      this.dht.registrar.handle(c.PROTOCOL_DHT, this._rpc)
+      this.dht.registrar.handle(this.dht.protocol, this._rpc)
     }
 
     // register protocol with topology
     const topology = new MulticodecTopology({
-      multicodecs: [c.PROTOCOL_DHT],
+      multicodecs: [this.dht.protocol],
       handlers: {
         onConnect: this._onPeerConnected,
         onDisconnect: () => {}
@@ -129,7 +129,7 @@ class Network {
       conn = await this.dht.dialer.connectToPeer(to)
     }
 
-    const { stream } = await conn.newStream(c.PROTOCOL_DHT)
+    const { stream } = await conn.newStream(this.dht.protocol)
 
     return this._writeReadMessage(stream, msg.serialize())
   }
@@ -153,7 +153,7 @@ class Network {
     if (!conn) {
       conn = await this.dht.dialer.connectToPeer(to)
     }
-    const { stream } = await conn.newStream(c.PROTOCOL_DHT)
+    const { stream } = await conn.newStream(this.dht.protocol)
 
     return this._writeMessage(stream, msg.serialize())
   }

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -961,13 +961,13 @@ describe('KadDHT', () => {
     it('should not find peers with different protocols', async function () {
       this.timeout(40 * 1000)
 
-      const protocol1 = '/test/1.0.0'
-      const protocol2 = '/test/2.0.0'
+      const protocol1 = '/test1'
+      const protocol2 = '/test2'
 
       const tdht = new TestDHT()
       const dhts = []
-      dhts.push(...await tdht.spawn(2, { protocol: protocol1 }))
-      dhts.push(...await tdht.spawn(2, { protocol: protocol2 }))
+      dhts.push(...await tdht.spawn(2, { protocolPrefix: protocol1 }))
+      dhts.push(...await tdht.spawn(2, { protocolPrefix: protocol2 }))
 
       // Connect all
       await Promise.all([
@@ -985,6 +985,18 @@ describe('KadDHT', () => {
         return tdht.teardown()
       }
       throw new Error('seperate protocols should have their own topologies and communication streams')
+    })
+
+    it('force legacy protocol', async function () {
+      this.timeout(40 * 1000)
+
+      const protocol = '/test/dht/0.0.0'
+
+      const tdht = new TestDHT()
+      const [dht] = await tdht.spawn(1, { protocolPrefix: protocol, forceProtocolLegacy: true })
+
+      expect(dht.protocol).to.eql(protocol)
+      return tdht.teardown()
     })
   })
 })

--- a/test/utils/test-dht.js
+++ b/test/utils/test-dht.js
@@ -35,6 +35,7 @@ class TestDHT {
       randomWalk: {
         enabled: false
       },
+      protocol: PROTOCOL_DHT,
       ...options
     }
 
@@ -46,10 +47,10 @@ class TestDHT {
         (node) => node.peerId.toB58String() === remotePeerB58
       )
 
-      const localOnConnect = regRecord[PROTOCOL_DHT].onConnect
-      const remoteOnConnect = remoteDht.regRecord[PROTOCOL_DHT].onConnect
+      const localOnConnect = regRecord[options.protocol].onConnect
+      const remoteOnConnect = remoteDht.regRecord[options.protocol].onConnect
 
-      const remoteHandler = remoteDht.regRecord[PROTOCOL_DHT].handler
+      const remoteHandler = remoteDht.regRecord[options.protocol].handler
 
       // Notice peers of connection
       const [c0, c1] = ConnectionPair()
@@ -65,7 +66,7 @@ class TestDHT {
           if (!localDHT._clientMode) await remoteOnConnect(peerId, c0)
 
           await remoteHandler({
-            protocol: PROTOCOL_DHT,
+            protocol: options.protocol,
             stream: c0.stream,
             connection: {
               remotePeer: peerId
@@ -116,8 +117,8 @@ class TestDHT {
   }
 
   async connect (dhtA, dhtB) {
-    const onConnectA = dhtA.regRecord[PROTOCOL_DHT].onConnect
-    const onConnectB = dhtB.regRecord[PROTOCOL_DHT].onConnect
+    const onConnectA = dhtA.regRecord[dhtA.protocol].onConnect
+    const onConnectB = dhtB.regRecord[dhtB.protocol].onConnect
 
     const [c0, c1] = ConnectionPair()
 

--- a/test/utils/test-dht.js
+++ b/test/utils/test-dht.js
@@ -35,7 +35,7 @@ class TestDHT {
       randomWalk: {
         enabled: false
       },
-      protocol: PROTOCOL_DHT,
+      protocolPrefix: '/ipfs',
       ...options
     }
 
@@ -47,10 +47,10 @@ class TestDHT {
         (node) => node.peerId.toB58String() === remotePeerB58
       )
 
-      const localOnConnect = regRecord[options.protocol].onConnect
-      const remoteOnConnect = remoteDht.regRecord[options.protocol].onConnect
+      const localOnConnect = regRecord[options.protocolPrefix + PROTOCOL_DHT].onConnect
+      const remoteOnConnect = remoteDht.regRecord[options.protocolPrefix + PROTOCOL_DHT].onConnect
 
-      const remoteHandler = remoteDht.regRecord[options.protocol].handler
+      const remoteHandler = remoteDht.regRecord[options.protocolPrefix + PROTOCOL_DHT].handler
 
       // Notice peers of connection
       const [c0, c1] = ConnectionPair()
@@ -66,7 +66,7 @@ class TestDHT {
           if (!localDHT._clientMode) await remoteOnConnect(peerId, c0)
 
           await remoteHandler({
-            protocol: options.protocol,
+            protocol: options.protocolPrefix + PROTOCOL_DHT,
             stream: c0.stream,
             connection: {
               remotePeer: peerId


### PR DESCRIPTION
This PR adds the ability to use unique multicodec protocols for the DHT, which enables multiple DHTs to operate separately in a single libp2p instance, as well as specifying they are unique from the IPFS ecosystem.

Includes a test to ensure peers with separate protocols do not find each other. I have also run external integration tests with a libp2p instance with no problems. I am open to adding more tests if there are more cases to test for.

The protocol to use can be specified by passing the `protocol` argument in the constructor argument, which defaults to what currently is in use: `"/ipfs/kad/1.0.0"`

The `multicodec` module export used in other js-libp2p packages still exports the same default value, so all external references to it should remain unaffected.

Please note, this may not a complete solution, since each DHT instance will have it's own peer topology while using the same peerStore. My knowledge of libp2p is limited in this capacity, so more work may need to be done to enable full functionality with multiple topologies.

For those interested, the code necessary to add a custom secondary DHT to a libp2p instance is as follows:
```javascript
/**
 * @param {Libp2p} libp2p
 */
function addDHT(libp2p) {
    const customDHT = new KadDHT({
        libp2p,
        dialer: libp2p.dialer,
        peerId: libp2p.peerId,
        peerStore: libp2p.peerStore,
        registrar: libp2p.registrar,
        protocol: '/custom/kad/1.0.0'
    })
    customDHT.start()
    customDHT.on('peer', libp2p._onDiscoveryPeer) // DISCLAIMER: You may want to implement your own discovery event function
    return customDHT
}
```