### PR TITLE
[Feature] adds removeLocal function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -276,6 +276,7 @@ class KadDHT extends EventEmitter {
   /**
    * Remove the given key from the local datastore.
    * @param {Uint8Array} key
+   * @returns {Promise<void>}
    */
   async removeLocal (key) {
     this._log('removeLocal: %b', key)

--- a/src/index.js
+++ b/src/index.js
@@ -273,6 +273,24 @@ class KadDHT extends EventEmitter {
     return this.contentFetching.getMany(key, nvals, options)
   }
 
+  /**
+   * Remove the given key from the local datastore.
+   * @param {Uint8Array} key
+   */
+  async removeLocal (key) {
+    this._log('removeLocal: %b', key)
+    const dsKey = utils.bufferToKey(key)
+
+    try {
+      await this.datastore.delete(dsKey)
+    } catch (err) {
+      if (err.code === 'ERR_NOT_FOUND') {
+        return undefined
+      }
+      throw err
+    }
+  }
+
   // ----------- Content Routing
 
   /**

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -186,6 +186,31 @@ describe('KadDHT', () => {
       return tdht.teardown()
     })
 
+    it('put - removeLocal', async function () {
+      this.timeout(10 * 1000)
+
+      const tdht = new TestDHT()
+      const key = uint8ArrayFromString('/v/hello')
+      const value = uint8ArrayFromString('world')
+
+      const [dht] = await tdht.spawn(2)
+
+      await dht.put(key, value)
+
+      const res = await dht.get(uint8ArrayFromString('/v/hello'), { timeout: 1000 })
+      expect(res).to.eql(value)
+
+      // remove from the local datastore
+      await dht.removeLocal(key)
+      try {
+        await dht.datastore.get(key)
+      } catch (err) {
+        expect(err).to.exist()
+        expect(err.code).to.be.eql('ERR_NOT_FOUND')
+        return tdht.teardown()
+      }
+    })
+
     it('put - get', async function () {
       this.timeout(10 * 1000)
 


### PR DESCRIPTION
Adds the ability for a dht key/value pair entry to be removed from the local datastore. This essentially acts as dereferencing functionality for the peer.

### Usage

```js
await dht.removeLocal(uint8ArrayFromString('/v/hello'))
```