### PR TITLE
fix: do not throw on empty provider list

### DIFF
--- a/src/content-routing/index.js
+++ b/src/content-routing/index.js
@@ -148,10 +148,6 @@ module.exports = (dht) => {
         })
       })
 
-      if (out.length === 0) {
-        throw errcode(new Error('no providers found'), 'ERR_NOT_FOUND')
-      }
-
       for (const pData of out.toArray()) {
         yield pData
       }


### PR DESCRIPTION
If no content providers can be found, just be an empty iterator
instead of throwing.

This is necessary because multiple findProv strategies are tried
higher up the stack, at which point we make the decision whether
to throw or not.

This makes the behaviour consistent with the delegated content
routing module.