### PR TITLE
Fix: findPeer() trying to find self returns AggregateError instead of more suitable error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -368,6 +368,9 @@ class KadDHT extends EventEmitter {
    * @returns {Promise<{ id: PeerId, multiaddrs: Multiaddr[] }>}
    */
   async findPeer (id, options = { timeout: 60000 }) { // eslint-disable-line require-await
+    if (id._idB58String == this.peerId._idB58String) {
+      throw errcode(new Error('Cannot find self'), 'ERR_DIAL_SELF')
+    }
     return this.peerRouting.findPeer(id, options)
   }
 


### PR DESCRIPTION
PR in response to an issue at [js-libp2p](https://github.com/libp2p/js-libp2p/issues/827) that returned an abstract aggregate error instead of "a more suitable error." This PR returns an `ERR_DIAL_SELF` error when passing one's own peer ID to KadDHT.findPeer() by comparing the ID of the passed parameter to the id of this.peerId like so:

`if (id._idB58String == this.peerId._idB58String) {
      throw errcode(new Error('Cannot find self'), 'ERR_DIAL_SELF')
    }`