### PR TITLE
fix: browser override path

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,6 @@
     "Thomas Eizinger <thomas@eizinger.io>"
   ],
   "browser": {
-    "src/routing-table/generated-prefix-list.json": "src/routing-table/generated-prefix-list-browser.json"
+    "./src/routing-table/generated-prefix-list.json": "./src/routing-table/generated-prefix-list-browser.json"
   }
 }


### PR DESCRIPTION
Webpack requires the `./` otherwise you get:

```
ERROR in ./node_modules/libp2p-kad-dht/src/routing-table/index.js 6:27-66
Module not found: Error: Can't resolve './generated-prefix-list.json' in '/Users/alex/test/webpack/node_modules/libp2p-kad-dht/src/routing-table'
```