### PR TITLE
feat: ping old DHT peers before eviction

### DIFF
--- a/src/routing-table/index.js
+++ b/src/routing-table/index.js
@@ -14,6 +14,8 @@ const log = Object.assign(debug('libp2p:dht:routing-table'), {
 })
 // @ts-ignore
 const length = require('it-length')
+const { default: Queue } = require('p-queue')
+const pTimeout = require('p-timeout')
 
 /**
  * @typedef {object} KBucketPeer
@@ -54,12 +56,14 @@ class RoutingTable {
    * @param {object} [options]
    * @param {number} [options.kBucketSize=20]
    * @param {number} [options.refreshInterval=30000]
+   * @param {number} [options.pingTimeout=10000]
    */
-  constructor (dht, { kBucketSize, refreshInterval } = {}) {
+  constructor (dht, { kBucketSize, refreshInterval, pingTimeout } = {}) {
     this.peerId = dht.peerId
     this.dht = dht
     this._kBucketSize = kBucketSize || 20
     this._refreshInterval = refreshInterval || 30000
+    this._pingTimeout = pingTimeout || 10000
 
     /** @type {KBucketTree} */
     this.kb = new KBuck({
@@ -72,6 +76,7 @@ class RoutingTable {
 
     this._refreshTable = this._refreshTable.bind(this)
     this._onPing = this._onPing.bind(this)
+    this._pingQueue = new Queue({ concurrency: 1 })
   }
 
   async start () {
@@ -295,26 +300,48 @@ class RoutingTable {
   }
 
   /**
-   * Called on the `ping` event from `k-bucket`.
-   * Currently this just removes the oldest contact from
-   * the list, without actually pinging the individual peers.
-   * This is the same as go does, but should probably
-   * be upgraded to actually ping the individual peers.
+   * Called on the `ping` event from `k-bucket` when a bucket is full
+   * and cannot split.
+   *
+   * `oldContacts.length` is defined by the `numberOfNodesToPing` param
+   * passed to the `k-bucket` constructor.
+   *
+   * `oldContacts` will not be empty and is the list of contacts that
+   * have not been contacted for the longest.
    *
    * @param {KBucketPeer[]} oldContacts
    * @param {KBucketPeer} newContact
    */
   _onPing (oldContacts, newContact) {
-    // just use the first one (k-bucket sorts from oldest to newest)
-    const oldest = oldContacts[0]
+    // add to a queue so multiple ping requests do not overlap and we don't
+    // flood the network with ping requests if lots of newContact requests
+    // are received
+    this._pingQueue.add(async () => {
+      let responded = 0
 
-    if (oldest) {
-      // remove the oldest one
-      this.kb.remove(oldest.id)
-    }
+      try {
+        await Promise.all(
+          oldContacts.map(async oldContact => {
+            try {
+              log(`Pinging old contact ${oldContact.peer.toB58String()}`)
+              await pTimeout(this.dht.libp2p.ping(oldContact.peer), this._pingTimeout)
+              responded++
+            } catch (err) {
+              log.error('Could not ping peer', err)
+              log(`Evicting old contact after ping failed ${oldContact.peer.toB58String()}`)
+              this.kb.remove(oldContact.id)
+            }
+          })
+        )
 
-    // add the new one
-    this.kb.add(newContact)
+        if (responded < oldContacts.length) {
+          log(`Adding new contact ${newContact.peer.toB58String()}`)
+          this.kb.add(newContact)
+        }
+      } catch (err) {
+        log.error('Could not process k-bucket ping event', err)
+      }
+    })
   }
 
   // -- Public Interface


### PR DESCRIPTION
Updates the DHT contact logic to ping the old peers when buckets are full and only evict if the peer does not respond.

Runs ping requests in a queue to prevent flooding the network if lots and lots of peers are added very quickly.

Uses the generic libp2p ping, rather than the DHT RPC ping, I'm not sure if this is correct.  It looks like `go-libp2p-kad-dht` [just tries to dial the remote peer](https://github.com/libp2p/go-libp2p-kad-dht/blob/35cca9a2555a0f149b4b9ad2e32555f9dc18ec37/rtrefresh/rt_refresh_manager.go#L173-L190) and treats that as success, so maybe this should just do that?