### PR TITLE
chore: change error type

### DIFF
--- a/src/content-fetching/index.js
+++ b/src/content-fetching/index.js
@@ -66,7 +66,7 @@ module.exports = (dht) => {
       if (dht._isSelf(v.from)) {
         try {
           await dht._putLocal(key, fixupRec)
-        } catch (err) {
+        } catch (/** @type {any} */ err) {
           dht._log.error('Failed error correcting self', err)
         }
         return
@@ -75,7 +75,7 @@ module.exports = (dht) => {
       // send correction
       try {
         await dht._putValueToPeer(key, fixupRec, v.from)
-      } catch (err) {
+      } catch (/** @type {any} */ err) {
         dht._log.error('Failed error correcting entry', err)
       }
     }))
@@ -118,7 +118,7 @@ module.exports = (dht) => {
           counterAll += 1
           await dht._putValueToPeer(key, record, peer)
           counterSuccess += 1
-        } catch (err) {
+        } catch (/** @type {any} */ err) {
           dht._log.error('Failed to put to peer (%b): %s', peer.id, err)
         }
       })
@@ -152,7 +152,7 @@ module.exports = (dht) => {
 
       try {
         i = libp2pRecord.selection.bestRecord(dht.selectors, key, recs)
-      } catch (err) {
+      } catch (/** @type {any} */ err) {
         // Assume the first record if no selector available
         if (err.code !== 'ERR_NO_SELECTOR_FUNCTION_FOR_RECORD_KEY') {
           throw err
@@ -189,7 +189,7 @@ module.exports = (dht) => {
 
       try {
         localRec = await getLocal(key)
-      } catch (err) {
+      } catch (/** @type {any} */ err) {
         if (nvals === 0) {
           throw err
         }
@@ -243,7 +243,7 @@ module.exports = (dht) => {
             const results = await dht._getValueOrPeers(peer, key)
             rec = results.record
             peers = results.peers
-          } catch (err) {
+          } catch (/** @type {any} */ err) {
             // If we have an invalid record we just want to continue and fetch a new one.
             if (err.code !== 'ERR_INVALID_RECORD') {
               throw err
@@ -288,7 +288,7 @@ module.exports = (dht) => {
 
       try {
         await pTimeout(query.run(rtp), options.timeout)
-      } catch (err) {
+      } catch (/** @type {any} */ err) {
         if (vals.length === 0) {
           throw err
         }

--- a/src/content-routing/index.js
+++ b/src/content-routing/index.js
@@ -61,7 +61,7 @@ module.exports = (dht) => {
         dht._log(`putProvider ${key} to ${peer.toB58String()}`)
         try {
           await dht.network.sendMessage(peer, msg)
-        } catch (err) {
+        } catch (/** @type {any} */ err) {
           errors.push(err)
         }
       }
@@ -175,7 +175,7 @@ module.exports = (dht) => {
           query.run(peers),
           providerTimeout
         )
-      } catch (err) {
+      } catch (/** @type {any} */ err) {
         if (err.name !== pTimeout.TimeoutError.name) {
           throw err
         }

--- a/src/index.js
+++ b/src/index.js
@@ -288,7 +288,7 @@ class KadDHT extends EventEmitter {
 
     try {
       await this.datastore.delete(dsKey)
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       if (err.code === 'ERR_NOT_FOUND') {
         return undefined
       }
@@ -443,7 +443,7 @@ class KadDHT extends EventEmitter {
     let rawRecord
     try {
       rawRecord = await this.datastore.get(dsKey)
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       if (err.code === 'ERR_NOT_FOUND') {
         return undefined
       }
@@ -536,7 +536,7 @@ class KadDHT extends EventEmitter {
       // We have a record
       try {
         await this._verifyRecordOnline(record)
-      } catch (err) {
+      } catch (/** @type {any} */ err) {
         const errMsg = 'invalid record received, discarded'
         this._log(errMsg)
         throw errcode(new Error(errMsg), 'ERR_INVALID_RECORD')

--- a/src/peer-routing/index.js
+++ b/src/peer-routing/index.js
@@ -282,7 +282,7 @@ module.exports = (dht) => {
 
       try {
         pk = await getPublicKeyFromNode(peer)
-      } catch (err) {
+      } catch (/** @type {any} */ err) {
         // try dht directly
         const pkKey = utils.keyForPublicKey(peer)
         const value = await dht.get(pkKey)

--- a/src/providers.js
+++ b/src/providers.js
@@ -128,7 +128,7 @@ class Providers {
             deleted.set(cid, peers)
           }
           count++
-        } catch (err) {
+        } catch (/** @type {any} */ err) {
           this._log.error(err.message)
         }
       }

--- a/src/query/worker-queue.js
+++ b/src/query/worker-queue.js
@@ -167,7 +167,7 @@ class WorkerQueue {
     let continueQuerying, continueQueryingError
     try {
       continueQuerying = await this.run.continueQuerying(this)
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       continueQueryingError = err
     }
 
@@ -199,7 +199,7 @@ class WorkerQueue {
     let state, execError
     try {
       state = await this.execQuery(peer)
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       execError = err
     }
 
@@ -239,7 +239,7 @@ class WorkerQueue {
     let res, queryError
     try {
       res = await this.path.queryFunc(peer)
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       queryError = err
     }
 

--- a/src/routing-table/index.js
+++ b/src/routing-table/index.js
@@ -130,12 +130,12 @@ class RoutingTable {
             for (let n = index + 1; n < lastCpl + 1; n++) {
               try {
                 await this._refreshCommonPrefixLength(n, lastRefresh, force === true)
-              } catch (err) {
+              } catch (/** @type {any} */ err) {
                 log.error(err)
               }
             }
           }
-        } catch (err) {
+        } catch (/** @type {any} */ err) {
           log.error(err)
         }
       })

--- a/src/rpc/handlers/add-provider.js
+++ b/src/rpc/handlers/add-provider.js
@@ -32,7 +32,7 @@ module.exports = (dht) => {
     let cid
     try {
       cid = CID.decode(msg.key)
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       const errMsg = `Invalid CID: ${err.message}`
       throw errcode(new Error(errMsg), 'ERR_INVALID_CID')
     }

--- a/src/rpc/handlers/get-providers.js
+++ b/src/rpc/handlers/get-providers.js
@@ -26,7 +26,7 @@ module.exports = (dht) => {
     let cid
     try {
       cid = CID.decode(msg.key)
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       throw errcode(new Error(`Invalid CID: ${err.message}`), 'ERR_INVALID_CID')
     }
 

--- a/src/rpc/index.js
+++ b/src/rpc/index.js
@@ -31,7 +31,7 @@ module.exports = (dht) => {
 
     try {
       await dht._add(peerId)
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       log.error('Failed to update the kbucket store', err)
     }
 
@@ -55,7 +55,7 @@ module.exports = (dht) => {
 
     try {
       await dht._add(peerId)
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       log.error(err)
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -210,7 +210,7 @@ exports.withTimeout = (asyncFn, time) => {
 
     try {
       res = await pTimeout(asyncFn(...args), time)
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       if (err instanceof pTimeout.TimeoutError) {
         throw errcode(err, 'ETIMEDOUT')
       }

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -180,7 +180,7 @@ describe('KadDHT', () => {
       await dht.removeLocal(key)
       try {
         await dht.datastore.get(key)
-      } catch (err) {
+      } catch (/** @type {any} */ err) {
         expect(err).to.exist()
         expect(err.code).to.be.eql('ERR_NOT_FOUND')
       } finally {

--- a/test/kad-utils.spec.js
+++ b/test/kad-utils.spec.js
@@ -40,7 +40,7 @@ describe('kad utils', () => {
       let err
       try {
         await asyncFn()
-      } catch (_err) {
+      } catch (/** @type {any} */ _err) {
         err = _err
       }
 

--- a/test/network.spec.js
+++ b/test/network.spec.js
@@ -149,7 +149,7 @@ describe('Network', () => {
 
       try {
         await dht.network.sendRequest(dht.peerId, msg)
-      } catch (err) {
+      } catch (/** @type {any} */ err) {
         expect(err).to.exist()
         expect(err.message).to.match(/timed out/)
 

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -105,7 +105,7 @@ describe('Query', () => {
 
     try {
       await q.run([peerIds[1]])
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       expect(err).to.exist()
       expect(err.message).to.eql('fail')
       return

--- a/test/rpc/handlers/add-provider.spec.js
+++ b/test/rpc/handlers/add-provider.spec.js
@@ -48,7 +48,7 @@ describe('rpc - handlers - AddProvider', () => {
       it(t.error.toString(), async () => {
         try {
           await handler(dht)(peerIds[0], t.message)
-        } catch (err) {
+        } catch (/** @type {any} */ err) {
           expect(err).to.exist()
           expect(err.code).to.eql(t.error)
           return

--- a/test/rpc/handlers/get-providers.spec.js
+++ b/test/rpc/handlers/get-providers.spec.js
@@ -40,7 +40,7 @@ describe('rpc - handlers - GetProviders', () => {
 
     try {
       await handler(dht)(peerIds[0], msg)
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       expect(err.code).to.eql('ERR_INVALID_CID')
     }
   })

--- a/test/rpc/handlers/get-value.spec.js
+++ b/test/rpc/handlers/get-value.spec.js
@@ -35,7 +35,7 @@ describe('rpc - handlers - GetValue', () => {
 
     try {
       await handler(dht)(peerIds[0], msg)
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       expect(err.code).to.eql('ERR_INVALID_KEY')
       return
     }

--- a/test/rpc/handlers/put-value.spec.js
+++ b/test/rpc/handlers/put-value.spec.js
@@ -39,7 +39,7 @@ describe('rpc - handlers - PutValue', () => {
 
     try {
       await handler(dht)(peerIds[0], msg)
-    } catch (err) {
+    } catch (/** @type {any} */ err) {
       expect(err.code).to.eql('ERR_EMPTY_RECORD')
       return
     }


### PR DESCRIPTION
Recent typescript has changed the default error type from `any` to `unknown` so we have to explicitly change it back to `any`.