### PR TITLE
fix: remove trailing slash from datastore prefixes

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -15,9 +15,9 @@ exports.MAX_RECORD_AGE = 36 * hour
 
 exports.PROTOCOL_DHT = '/kad/1.0.0'
 
-exports.RECORD_KEY_PREFIX = '/dht/record/'
+exports.RECORD_KEY_PREFIX = '/dht/record'
 
-exports.PROVIDER_KEY_PREFIX = '/dht/provider/'
+exports.PROVIDER_KEY_PREFIX = '/dht/provider'
 
 exports.PROVIDERS_LRU_CACHE_SIZE = 256
 

--- a/src/providers.js
+++ b/src/providers.js
@@ -223,7 +223,7 @@ class Providers {
 function makeProviderKey (cid) {
   cid = typeof cid === 'string' ? cid : uint8ArrayToString(cid.multihash.bytes, 'base32')
 
-  return PROVIDER_KEY_PREFIX + cid
+  return `${PROVIDER_KEY_PREFIX}/${cid}`
 }
 
 /**

--- a/test/generate-peers/generate-peers.spec.js
+++ b/test/generate-peers/generate-peers.spec.js
@@ -27,6 +27,7 @@ async function fromGo (targetCpl, randPrefix, localKadId) {
 }
 
 describe('generate peers', function () {
+  this.timeout(540 * 1000)
   const go = which.sync('go', { nothrow: true })
 
   if (!go) {
@@ -37,14 +38,13 @@ describe('generate peers', function () {
 
   let refresh
 
-  before(async () => {
+  before(async function () {
     await execa(go, ['build', 'generate-peer.go'], {
       cwd: __dirname
     })
   })
 
   beforeEach(async function () {
-    this.timeout(540 * 1000)
     const id = await PeerId.create({ bits: 512 })
 
     const table = new RoutingTable({

--- a/test/generate-peers/generate-peers.spec.js
+++ b/test/generate-peers/generate-peers.spec.js
@@ -38,13 +38,13 @@ describe('generate peers', function () {
 
   let refresh
 
-  before(async function () {
+  before(async () => {
     await execa(go, ['build', 'generate-peer.go'], {
       cwd: __dirname
     })
   })
 
-  beforeEach(async function () {
+  beforeEach(async () => {
     const id = await PeerId.create({ bits: 512 })
 
     const table = new RoutingTable({
@@ -73,7 +73,7 @@ describe('generate peers', function () {
     randPrefix: 49898
   }]
 
-  TEST_CASES.forEach(({ targetCpl, randPrefix }, index) => {
+  TEST_CASES.forEach(({ targetCpl, randPrefix }) => {
     it(`should generate peers targetCpl ${targetCpl} randPrefix ${randPrefix}`, async () => {
       const peerId = await PeerId.create({ bits: 512 })
       const localKadId = await convertPeerId(peerId)


### PR DESCRIPTION
Otherwise you get double slashes in datastore keys.