### PR TITLE
fix: require at least one successful put

### DIFF
--- a/src/dual-kad-dht.js
+++ b/src/dual-kad-dht.js
@@ -138,7 +138,7 @@ class DualKadDHT extends EventEmitter {
     }
 
     // verify if we were able to put to enough peers
-    const minPeers = options.minPeers || counterAll // Ensure we have a default `minPeers`
+    const minPeers = options.minPeers == null ? counterAll || 1 : options.minPeers // Ensure we have a default `minPeers`
 
     if (counterSuccess < minPeers) {
       const error = errCode(new Error(`Failed to put value to enough peers: ${counterSuccess}/${minPeers}`), 'ERR_NOT_ENOUGH_PUT_PEERS')

--- a/src/dual-kad-dht.js
+++ b/src/dual-kad-dht.js
@@ -137,9 +137,10 @@ class DualKadDHT extends EventEmitter {
       }
     }
 
-    // verify if we were able to put to enough peers
-    const minPeers = options.minPeers == null ? counterAll || 1 : options.minPeers // Ensure we have a default `minPeers`
+    // Ensure we have a default `minPeers`
+    const minPeers = options.minPeers == null ? counterAll || 1 : options.minPeers
 
+    // verify if we were able to put to enough peers
     if (counterSuccess < minPeers) {
       const error = errCode(new Error(`Failed to put value to enough peers: ${counterSuccess}/${minPeers}`), 'ERR_NOT_ENOUGH_PUT_PEERS')
       log.error(error)

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -163,7 +163,7 @@ describe('KadDHT', () => {
       const [dht] = await tdht.spawn(1)
 
       // Exchange data through the dht
-      await drain(dht.put(key, value))
+      await drain(dht.put(key, value, { minPeers: 0 }))
 
       const res = await last(dht.get(key))
       expect(res).to.have.property('value').that.equalBytes(value)
@@ -341,8 +341,8 @@ describe('KadDHT', () => {
       const dhtASpy = sinon.spy(dhtA._lan._network, 'sendRequest')
 
       // Put before peers connected
-      await drain(dhtA.put(key, valueA))
-      await drain(dhtB.put(key, valueB))
+      await drain(dhtA.put(key, valueA, { minPeers: 0 }))
+      await drain(dhtB.put(key, valueB, { minPeers: 0 }))
 
       // Connect peers
       await tdht.connect(dhtA, dhtB)

--- a/test/rpc/handlers/get-value.spec.js
+++ b/test/rpc/handlers/get-value.spec.js
@@ -54,7 +54,7 @@ describe('rpc - handlers - GetValue', () => {
     const key = uint8ArrayFromString('hello')
     const value = uint8ArrayFromString('world')
 
-    await drain(dht.put(key, value))
+    await drain(dht.put(key, value, { minPeers: 0 }))
 
     const msg = new Message(T, key, 0)
     const response = await handler.handle(peerIds[0], msg)


### PR DESCRIPTION
If no minPeers is specified, require at least one success during a
dht put operation, unless minPeers is explicitly `0`