### PR TITLE
chore: guard on table refresh running

### DIFF
--- a/src/routing-table/refresh.js
+++ b/src/routing-table/refresh.js
@@ -218,10 +218,6 @@ class RoutingTableRefresh {
    * and the current peer
    */
   _maxCommonPrefix () {
-    if (!this._routingTable.kb.localNodeId) {
-      return 0
-    }
-
     // xor our KadId with every KadId in the k-bucket tree,
     // return the longest id prefix that is the same
     let prefixLength = 0
@@ -256,6 +252,10 @@ class RoutingTableRefresh {
    * Yields the common prefix length of every peer in the table
    */
   * _prefixLengths () {
+    if (!this._routingTable.kb) {
+      return
+    }
+
     for (const { id } of this._routingTable.kb.toIterable()) {
       const distance = uint8ArrayXor(this._routingTable.kb.localNodeId, id)
       let leadingZeros = 0

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -766,11 +766,10 @@ describe('KadDHT', () => {
         tdht.connect(dhts[2], dhts[3])
       ])
 
-      const stub = sinon.stub(dhts[0]._lan._routingTable, 'closestPeers').returns([])
+      dhts[0]._lan.findPeer = sinon.stub().returns([])
+      dhts[0]._wan.findPeer = sinon.stub().returns([])
 
       await expect(drain(dhts[0].findPeer(ids[3]))).to.eventually.be.rejected().property('code', 'ERR_LOOKUP_FAILED')
-
-      stub.restore()
     })
   })
 })

--- a/test/routing-table.spec.js
+++ b/test/routing-table.spec.js
@@ -26,6 +26,11 @@ describe('Routing Table', () => {
       peerId: lipbp2p.peerId,
       dialer: lipbp2p
     })
+    await table.start()
+  })
+
+  afterEach(async () => {
+    await table.stop()
   })
 
   it('add', async function () {
@@ -90,7 +95,8 @@ describe('Routing Table', () => {
     table._pingQueue = {
       add: (f) => {
         fn = f
-      }
+      },
+      clear: () => {}
     }
 
     const peerIds = [
@@ -135,7 +141,8 @@ describe('Routing Table', () => {
     table._pingQueue = {
       add: (f) => {
         fn = f
-      }
+      },
+      clear: () => {}
     }
 
     const peerIds = [


### PR DESCRIPTION
We queue up ping requests to see if we should evict peers from the
routing table - if we are being shut down the requests will be
aborted so check to make sure we are still running before starting
another.

Also, don't evict a peer because the request failed if we aren't
running as it may have been cancelled which doesn't mean the remote
peer is invalid.