### PR TITLE
fix: do not send messages if the network is not running

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -79,6 +79,10 @@ class Network extends EventEmitter {
    * @param {AbortSignal} [options.signal]
    */
   async * sendRequest (to, msg, options = {}) {
+    if (!this._running) {
+      return
+    }
+
     this._log('sending %s to %p', MESSAGE_TYPE_LOOKUP[msg.type], to)
 
     try {
@@ -111,6 +115,10 @@ class Network extends EventEmitter {
    * @param {AbortSignal} [options.signal]
    */
   async * sendMessage (to, msg, options = {}) {
+    if (!this._running) {
+      return
+    }
+
     this._log('sending %s to %p', MESSAGE_TYPE_LOOKUP[msg.type], to)
 
     yield dialingPeerEvent({ peer: to })


### PR DESCRIPTION
Otherwise we can end up dialing a node during libp2p shut down