### PR TITLE
chore: update libp2p-crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/libp2p/js-libp2p-kad-dht/issues"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=15.0.0"
   },
   "eslintConfig": {
     "extends": "ipfs",
@@ -65,7 +65,7 @@
     "it-pipe": "^1.1.0",
     "it-take": "^1.0.2",
     "k-bucket": "^5.1.0",
-    "libp2p-crypto": "^0.20.0",
+    "libp2p-crypto": "^0.21.0",
     "libp2p-interfaces": "^1.3.0",
     "libp2p-record": "^0.10.4",
     "multiaddr": "^10.0.0",


### PR DESCRIPTION
BREAKING CHANGE: requires node 15+