### PR TITLE
fix: only provide to wan in server mode

### DIFF
--- a/src/dual-kad-dht.js
+++ b/src/dual-kad-dht.js
@@ -209,10 +209,14 @@ class DualKadDHT extends EventEmitter {
     let success = 0
     const errors = []
 
-    for await (const event of merge(
-      this._lan.provide(key, options),
-      this._wan.provide(key, options)
-    )) {
+    const dhts = [this._lan]
+
+    // only run provide on the wan if we are in server mode
+    if (this._wan.isServer()) {
+      dhts.push(this._wan)
+    }
+
+    for await (const event of merge(...dhts.map(dht => dht.provide(key, options)))) {
       yield event
 
       if (event.name === 'SENDING_QUERY') {

--- a/src/kad-dht.js
+++ b/src/kad-dht.js
@@ -321,6 +321,13 @@ class KadDHT extends EventEmitter {
   }
 
   /**
+   * Is this DHT in server mode
+   */
+   isServer () {
+    return !this._clientMode
+  }
+
+  /**
    * Whether we are in client or server mode
    */
   enableServerMode () {

--- a/src/kad-dht.js
+++ b/src/kad-dht.js
@@ -323,7 +323,7 @@ class KadDHT extends EventEmitter {
   /**
    * Is this DHT in server mode
    */
-   isServer () {
+  isServer () {
     return !this._clientMode
   }
 

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -471,7 +471,6 @@ describe('KadDHT', () => {
         tdht.connect(dhts[2], dhts[3])
       ])
 
-
       const wanSpy = sinon.spy(dhts[0]._wan, 'provide')
       const lanSpy = sinon.spy(dhts[0]._lan, 'provide')
 
@@ -490,7 +489,6 @@ describe('KadDHT', () => {
         tdht.connect(dhts[1], dhts[2]),
         tdht.connect(dhts[2], dhts[3])
       ])
-
 
       const wanSpy = sinon.spy(dhts[0]._wan, 'provide')
       const lanSpy = sinon.spy(dhts[0]._lan, 'provide')

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -461,6 +461,48 @@ describe('KadDHT', () => {
       }
     })
 
+    it('does not provide to wan if in client mode', async function () {
+      const dhts = await tdht.spawn(4)
+
+      // connect peers
+      await Promise.all([
+        tdht.connect(dhts[0], dhts[1]),
+        tdht.connect(dhts[1], dhts[2]),
+        tdht.connect(dhts[2], dhts[3])
+      ])
+
+
+      const wanSpy = sinon.spy(dhts[0]._wan, 'provide')
+      const lanSpy = sinon.spy(dhts[0]._lan, 'provide')
+
+      await drain(dhts[0].provide(values[0].cid))
+
+      expect(wanSpy.called).to.be.false()
+      expect(lanSpy.called).to.be.true()
+    })
+
+    it('provides to wan if in server mode', async function () {
+      const dhts = await tdht.spawn(4)
+
+      // connect peers
+      await Promise.all([
+        tdht.connect(dhts[0], dhts[1]),
+        tdht.connect(dhts[1], dhts[2]),
+        tdht.connect(dhts[2], dhts[3])
+      ])
+
+
+      const wanSpy = sinon.spy(dhts[0]._wan, 'provide')
+      const lanSpy = sinon.spy(dhts[0]._lan, 'provide')
+
+      dhts[0].enableServerMode()
+
+      await drain(dhts[0].provide(values[0].cid))
+
+      expect(wanSpy.called).to.be.true()
+      expect(lanSpy.called).to.be.true()
+    })
+
     it('find providers', async function () {
       this.timeout(20 * 1000)
 


### PR DESCRIPTION
If we are in server mode, provide to the wan and the lan. If we are in client mode, only provide to the lan.