### PR TITLE
feat: async peer store

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ import { create } from 'libp2p-kad-dht'
 /**
  * @param {Libp2p} libp2p
  */
-function addDHT(libp2p) {
+async function addDHT(libp2p) {
     const customDHT = create({
         libp2p,
         protocolPrefix: '/custom'
     })
-    customDHT.start()
+    await customDHT.start()
 
     return customDHT
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "it-take": "^1.0.2",
     "k-bucket": "^5.1.0",
     "libp2p-crypto": "^0.21.0",
-    "libp2p-interfaces": "^2.0.1",
+    "libp2p-interfaces": "^4.0.0",
     "libp2p-record": "^0.10.4",
     "multiaddr": "^10.0.0",
     "multiformats": "^9.4.5",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "it-filter": "^1.0.3",
     "it-last": "^1.0.6",
     "it-pair": "^1.0.0",
-    "libp2p": "^0.35.4",
+    "libp2p": "libp2p/js-libp2p#feat/async-peerstore",
     "lodash.random": "^3.2.0",
     "lodash.range": "^3.2.0",
     "p-retry": "^4.2.0",

--- a/src/dual-kad-dht.js
+++ b/src/dual-kad-dht.js
@@ -77,15 +77,15 @@ class DualKadDHT extends EventEmitter {
   /**
    * Whether we are in client or server mode
    */
-  enableServerMode () {
-    this._wan.enableServerMode()
+  async enableServerMode () {
+    await this._wan.enableServerMode()
   }
 
   /**
    * Whether we are in client or server mode
    */
-  enableClientMode () {
-    this._wan.enableClientMode()
+  async enableClientMode () {
+    await this._wan.enableClientMode()
   }
 
   /**
@@ -314,7 +314,7 @@ class DualKadDHT extends EventEmitter {
     log('getPublicKey %p', peer)
 
     // local check
-    const peerData = this._libp2p.peerStore.get(peer)
+    const peerData = await this._libp2p.peerStore.get(peer)
 
     if (peerData && peerData.id.pubKey) {
       log('getPublicKey: found local copy')
@@ -339,8 +339,8 @@ class DualKadDHT extends EventEmitter {
 
     const peerId = new PeerId(peer.id, undefined, pk)
     const addrs = ((peerData && peerData.addresses) || []).map((address) => address.multiaddr)
-    this._libp2p.peerStore.addressBook.add(peerId, addrs)
-    this._libp2p.peerStore.keyBook.set(peerId, pk)
+    await this._libp2p.peerStore.addressBook.add(peerId, addrs)
+    await this._libp2p.peerStore.keyBook.set(peerId, pk)
 
     return pk
   }

--- a/src/rpc/handlers/add-provider.js
+++ b/src/rpc/handlers/add-provider.js
@@ -19,7 +19,7 @@ class AddProviderHandler {
    * @param {object} params
    * @param {PeerId} params.peerId
    * @param {import('../../providers').Providers} params.providers
-   * @param {import('../../types').PeerStore} params.peerStore
+   * @param {import('libp2p/src/peer-store/types').PeerStore} params.peerStore
    */
   constructor ({ peerId, providers, peerStore }) {
     this._peerId = peerId
@@ -69,7 +69,7 @@ class AddProviderHandler {
 
         if (!this._peerId.equals(pi.id)) {
           // Add known address to peer store
-          this._peerStore.addressBook.add(pi.id, pi.multiaddrs)
+          await this._peerStore.addressBook.add(pi.id, pi.multiaddrs)
           await this._providers.addProvider(cid, pi.id)
         }
       })

--- a/src/rpc/handlers/get-value.js
+++ b/src/rpc/handlers/get-value.js
@@ -13,6 +13,7 @@ const log = utils.logger('libp2p:kad-dht:rpc:handlers:get-value')
 /**
  * @typedef {import('peer-id')} PeerId
  * @typedef {import('../types').DHTMessageHandler} DHTMessageHandler
+ * @typedef {import('libp2p-interfaces/src/keys/types').PublicKey} PublicKey
  */
 
 /**
@@ -22,7 +23,7 @@ class GetValueHandler {
   /**
    * @param {object} params
    * @param {PeerId} params.peerId
-   * @param {import('../../types').PeerStore} params.peerStore
+   * @param {import('libp2p/src/peer-store/types').PeerStore} params.peerStore
    * @param {import('../../peer-routing').PeerRouting} params.peerRouting
    * @param {import('interface-datastore').Datastore} params.records
    */
@@ -53,18 +54,18 @@ class GetValueHandler {
     if (utils.isPublicKeyKey(key)) {
       log('is public key')
       const idFromKey = utils.fromPublicKeyKey(key)
-      let id
+      /** @type {PublicKey | undefined} */
+      let pubKey
 
       if (this._peerId.equals(idFromKey)) {
-        id = this._peerId
+        pubKey = this._peerId.pubKey
       } else {
-        const peerData = this._peerStore.get(idFromKey)
-        id = peerData && peerData.id
+        pubKey = await this._peerStore.keyBook.get(idFromKey)
       }
 
-      if (id && id.pubKey) {
+      if (pubKey != null) {
         log('returning found public key')
-        response.record = new Record(key, id.pubKey.bytes)
+        response.record = new Record(key, pubKey.bytes)
         return response
       }
     }

--- a/src/rpc/handlers/index.js
+++ b/src/rpc/handlers/index.js
@@ -16,7 +16,7 @@ const { PutValueHandler } = require('./put-value')
  * @param {object} params
  * @param {import('peer-id')} params.peerId
  * @param {import('../../providers').Providers} params.providers
- * @param {import('../../types').PeerStore} params.peerStore
+ * @param {import('libp2p/src/peer-store/types').PeerStore} params.peerStore
  * @param {import('../../types').Addressable} params.addressable
  * @param {import('../../peer-routing').PeerRouting} params.peerRouting
  * @param {import('interface-datastore').Datastore} params.records

--- a/src/rpc/index.js
+++ b/src/rpc/index.js
@@ -23,7 +23,7 @@ class RPC {
    * @param {import('../routing-table').RoutingTable} params.routingTable
    * @param {import('peer-id')} params.peerId
    * @param {import('../providers').Providers} params.providers
-   * @param {import('../types').PeerStore} params.peerStore
+   * @param {import('libp2p/src/peer-store/types').PeerStore} params.peerStore
    * @param {import('../types').Addressable} params.addressable
    * @param {import('../peer-routing').PeerRouting} params.peerRouting
    * @param {import('interface-datastore').Datastore} params.records

--- a/src/topology-listener.js
+++ b/src/topology-listener.js
@@ -12,7 +12,7 @@ class TopologyListener extends EventEmitter {
    * Create a new network
    *
    * @param {object} params
-   * @param {import('./types').Registrar} params.registrar
+   * @param {import('libp2p/src/registrar')} params.registrar
    * @param {string} params.protocol
    * @param {boolean} params.lan
    */
@@ -28,7 +28,7 @@ class TopologyListener extends EventEmitter {
   /**
    * Start the network
    */
-  start () {
+  async start () {
     if (this._running) {
       return
     }
@@ -46,7 +46,7 @@ class TopologyListener extends EventEmitter {
         onDisconnect: () => {}
       }
     })
-    this._registrarId = this._registrar.register(topology)
+    this._registrarId = await this._registrar.register(topology)
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,6 @@ import type PeerId from 'peer-id'
 import type { Multiaddr } from 'multiaddr'
 import type { CID } from 'multiformats/cid'
 import type { MuxedStream } from 'libp2p/src/upgrader'
-import type Topology from 'libp2p-interfaces/src/topology'
 import type { PublicKey } from 'libp2p-crypto'
 import type { Message } from './message/dht'
 
@@ -141,8 +140,8 @@ export interface DHT {
   put: (key: Uint8Array, value: Uint8Array, options?: QueryOptions) => AsyncIterable<QueryEvent>
 
   // enable/disable publishing
-  enableServerMode: () => void
-  enableClientMode: () => void
+  enableServerMode: () => Promise<void>
+  enableClientMode: () => Promise<void>
 
   // housekeeping
   refreshRoutingTable: () => Promise<void>
@@ -159,24 +158,6 @@ export interface Dialer {
 // Implemented by libp2p, should be moved to libp2p-interfaces eventually
 export interface Addressable {
   multiaddrs: Multiaddr[]
-}
-
-// Implemented by libp2p.registrar, should be moved to libp2p-interfaces eventually
-export interface Registrar {
-  register: (topology: Topology) => string
-  unregister: (id: string) => boolean
-}
-
-// Implemented by libp2p.peerStore, should be moved to libp2p-interfaces eventually
-export interface PeerStore {
-  addressBook: AddressBook
-  get: (peerId: PeerId) => { id: PeerId, addresses: Array<{ multiaddr: Multiaddr }> } | undefined
-}
-
-// Implemented by libp2p.peerStore.addressStore, should be moved to libp2p-interfaces eventually
-export interface AddressBook {
-  add: (peerId: PeerId, addresses: Multiaddr[]) => void
-  get: (peerId: PeerId) => Array<{ multiaddr: Multiaddr }> | undefined
 }
 
 export interface Metrics {

--- a/test/kad-dht.spec.js
+++ b/test/kad-dht.spec.js
@@ -97,11 +97,11 @@ describe('KadDHT', () => {
       sinon.spy(dht._lan._network, 'start')
       sinon.spy(dht._lan._network, 'stop')
 
-      dht.start()
+      await dht.start()
       expect(dht._wan._network.start.calledOnce).to.equal(true)
       expect(dht._lan._network.start.calledOnce).to.equal(true)
 
-      dht.stop()
+      await dht.stop()
       expect(dht._wan._network.stop.calledOnce).to.equal(true)
       expect(dht._lan._network.stop.calledOnce).to.equal(true)
     })
@@ -112,15 +112,15 @@ describe('KadDHT', () => {
 
       dht._libp2p.handle = sinon.stub()
 
-      dht.start()
+      await dht.start()
       // lan dht is always in server mode
       expect(dht._libp2p.handle.callCount).to.equal(1)
 
-      dht.enableServerMode()
+      await dht.enableServerMode()
       // now wan dht should be in server mode too
       expect(dht._libp2p.handle.callCount).to.equal(2)
 
-      dht.stop()
+      await dht.stop()
     })
 
     it('client mode', async () => {
@@ -129,8 +129,8 @@ describe('KadDHT', () => {
 
       dht._libp2p.handle = sinon.stub()
 
-      dht.start()
-      dht.stop()
+      await dht.start()
+      await dht.stop()
 
       // lan dht is always in server mode
       expect(dht._libp2p.handle.callCount).to.equal(1)
@@ -139,17 +139,17 @@ describe('KadDHT', () => {
     it('should not fail when already started', async () => {
       const [dht] = await tdht.spawn(1, null, false)
 
-      dht.start()
-      dht.start()
-      dht.start()
+      await dht.start()
+      await dht.start()
+      await dht.start()
 
-      dht.stop()
+      await dht.stop()
     })
 
     it('should not fail to stop when was not started', async () => {
       const [dht] = await tdht.spawn(1, null, false)
 
-      dht.stop()
+      await dht.stop()
     })
   })
 
@@ -493,7 +493,7 @@ describe('KadDHT', () => {
       const wanSpy = sinon.spy(dhts[0]._wan, 'provide')
       const lanSpy = sinon.spy(dhts[0]._lan, 'provide')
 
-      dhts[0].enableServerMode()
+      await dhts[0].enableServerMode()
 
       await drain(dhts[0].provide(values[0].cid))
 
@@ -736,7 +736,7 @@ describe('KadDHT', () => {
       const dhts = await tdht.spawn(2)
 
       const ids = dhts.map((d) => d._libp2p.peerId)
-      dhts[0]._libp2p.peerStore.addressBook.add(dhts[1]._libp2p.peerId, [new Multiaddr('/ip4/160.1.1.1/tcp/80')])
+      await dhts[0]._libp2p.peerStore.addressBook.add(dhts[1]._libp2p.peerId, [new Multiaddr('/ip4/160.1.1.1/tcp/80')])
 
       const key = await dhts[0].getPublicKey(ids[1])
       expect(key).to.eql(dhts[1]._libp2p.peerId.pubKey)
@@ -753,7 +753,7 @@ describe('KadDHT', () => {
 
       await tdht.connect(dhts[0], dhts[1])
 
-      dhts[0]._libp2p.peerStore.addressBook.add(dhts[1]._libp2p.peerId, [new Multiaddr('/ip4/160.1.1.1/tcp/80')])
+      await dhts[0]._libp2p.peerStore.addressBook.add(dhts[1]._libp2p.peerId, [new Multiaddr('/ip4/160.1.1.1/tcp/80')])
 
       const key = await dhts[0].getPublicKey(ids[1])
       expect(uint8ArrayEquals(key, dhts[1]._libp2p.peerId.pubKey)).to.eql(true)

--- a/test/rpc/handlers/add-provider.spec.js
+++ b/test/rpc/handlers/add-provider.spec.js
@@ -87,7 +87,7 @@ describe('rpc - handlers - AddProvider', () => {
     expect(provs).to.have.length(1)
     expect(provs[0].id).to.eql(peerIds[0].id)
 
-    const bookEntry = dht._libp2p.peerStore.get(peerIds[0])
+    const bookEntry = await dht._libp2p.peerStore.get(peerIds[0])
     expect(bookEntry.addresses.map((address) => address.multiaddr)).to.eql([ma1])
   })
 })

--- a/test/rpc/handlers/get-value.spec.js
+++ b/test/rpc/handlers/get-value.spec.js
@@ -93,8 +93,8 @@ describe('rpc - handlers - GetValue', () => {
 
       const msg = new Message(T, key, 0)
 
-      dht._libp2p.peerStore.addressBook.add(other, [])
-      dht._libp2p.peerStore.keyBook.set(other, other.pubKey)
+      await dht._libp2p.peerStore.addressBook.add(other, [])
+      await dht._libp2p.peerStore.keyBook.set(other, other.pubKey)
 
       await dht._lan._routingTable.add(other)
       const response = await handler.handle(peerIds[0], msg)


### PR DESCRIPTION
Refactors interfaces and classes used by `libp2p-interfaces` to use the async peer store from https://github.com/libp2p/js-libp2p/pull/1058

BREAKING CHANGE: peerstore methods are now all async