### PR TITLE
fix: remove abort controller deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://github.com/libp2p/js-libp2p-kad-dht",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "any-signal": "^2.1.2",
+    "any-signal": "^3.0.0",
     "datastore-core": "^6.0.7",
     "debug": "^4.3.1",
     "err-code": "^3.0.0",
@@ -77,7 +77,7 @@
     "private-ip": "^2.3.3",
     "protobufjs": "^6.10.2",
     "streaming-iterables": "^6.0.0",
-    "timeout-abort-controller": "^2.0.0",
+    "timeout-abort-controller": "^3.0.0",
     "uint8arrays": "^3.0.0",
     "varint": "^6.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "libp2p-record": "^0.10.4",
     "multiaddr": "^10.0.0",
     "multiformats": "^9.4.5",
-    "native-abort-controller": "^1.0.4",
     "p-defer": "^3.0.0",
     "p-map": "^4.0.0",
     "p-queue": "^6.6.2",

--- a/src/query/manager.js
+++ b/src/query/manager.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { AbortController } = require('native-abort-controller')
 const { TimeoutController } = require('timeout-abort-controller')
 const { anySignal } = require('any-signal')
 const {

--- a/test/query.spec.js
+++ b/test/query.spec.js
@@ -8,7 +8,6 @@ const { QueryManager } = require('../src/query/manager')
 const createPeerId = require('./utils/create-peer-id')
 const all = require('it-all')
 const drain = require('it-drain')
-const { AbortController, AbortSignal } = require('native-abort-controller')
 const { sortClosestPeers } = require('./utils/sort-closest-peers')
 const { convertBuffer } = require('../src/utils')
 const {


### PR DESCRIPTION
`AbortController` and `AbortSignal` are in browsers and LTS node so the `abort-controller` and `native-abort-controller` deps aren't required any more.