### PR TITLE
fix: catch not found errors

### DIFF
--- a/src/dual-kad-dht.js
+++ b/src/dual-kad-dht.js
@@ -313,12 +313,25 @@ class DualKadDHT extends EventEmitter {
   async getPublicKey (peer, options = {}) {
     log('getPublicKey %p', peer)
 
-    // local check
-    const peerData = await this._libp2p.peerStore.get(peer)
+    let peerData
 
-    if (peerData && peerData.id.pubKey) {
-      log('getPublicKey: found local copy')
-      return peerData.id.pubKey
+    // local check
+    try {
+      peerData = await this._libp2p.peerStore.get(peer)
+
+      if (peerData.pubKey) {
+        log('getPublicKey: found local copy')
+        return peerData.pubKey
+      }
+
+      if (peerData.id.pubKey) {
+        log('getPublicKey: found local copy')
+        return peerData.id.pubKey
+      }
+    } catch (/** @type {any} */ err) {
+      if (err.code !== 'ERR_NOT_FOUND') {
+        throw err
+      }
     }
 
     // try the node directly

--- a/src/rpc/handlers/get-value.js
+++ b/src/rpc/handlers/get-value.js
@@ -60,7 +60,13 @@ class GetValueHandler {
       if (this._peerId.equals(idFromKey)) {
         pubKey = this._peerId.pubKey
       } else {
-        pubKey = await this._peerStore.keyBook.get(idFromKey)
+        try {
+          pubKey = await this._peerStore.keyBook.get(idFromKey)
+        } catch (/** @type {any} */ err) {
+          if (err.code !== 'ERR_NOT_FOUND') {
+            throw err
+          }
+        }
       }
 
       if (pubKey != null) {


### PR DESCRIPTION
Datastore errors are thrown by some peerstore methods