### PR TITLE
fix: update component metric API use

### DIFF
--- a/src/query/manager.js
+++ b/src/query/manager.js
@@ -115,7 +115,7 @@ class QueryManager {
     try {
       log('query:start')
       this._queries++
-      this._metrics && this._metrics.updateComponentMetric(`kad-dht-${this._lan ? 'lan' : 'wan'}`, METRIC_RUNNING_QUERIES, this._queries)
+      this._metrics && this._metrics.updateComponentMetric({ component: `kad-dht-${this._lan ? 'lan' : 'wan'}`, metric: METRIC_RUNNING_QUERIES, value: this._queries })
 
       if (peers.length === 0) {
         log.error('Running query with no peers')
@@ -161,7 +161,7 @@ class QueryManager {
       }
 
       this._queries--
-      this._metrics && this._metrics.updateComponentMetric(`kad-dht-${this._lan ? 'lan' : 'wan'}`, METRIC_RUNNING_QUERIES, this._queries)
+      this._metrics && this._metrics.updateComponentMetric({ component: `kad-dht-${this._lan ? 'lan' : 'wan'}`, metric: METRIC_RUNNING_QUERIES, value: this._queries })
 
       cleanUp.emit('cleanup')
       log(`query:done in ${Date.now() - (startTime || 0)}ms`)

--- a/src/routing-table/index.js
+++ b/src/routing-table/index.js
@@ -118,7 +118,7 @@ class RoutingTable {
                 timeoutController.clear()
               }
 
-              this._metrics && this._metrics.updateComponentMetric(`kad-dht-${this._lan ? 'lan' : 'wan'}`, METRIC_ROUTING_TABLE_SIZE, this.size)
+              this._metrics && this._metrics.updateComponentMetric({ component: `kad-dht-${this._lan ? 'lan' : 'wan'}`, metric: METRIC_ROUTING_TABLE_SIZE, value: this.size })
             }
           })
         )
@@ -193,7 +193,7 @@ class RoutingTable {
 
     this._log('added %p with kad id %b', peer, id)
 
-    this._metrics && this._metrics.updateComponentMetric(`kad-dht-${this._lan ? 'lan' : 'wan'}`, METRIC_ROUTING_TABLE_SIZE, this.size)
+    this._metrics && this._metrics.updateComponentMetric({ component: `kad-dht-${this._lan ? 'lan' : 'wan'}`, metric: METRIC_ROUTING_TABLE_SIZE, value: this.size })
   }
 
   /**
@@ -206,7 +206,7 @@ class RoutingTable {
 
     this.kb.remove(id)
 
-    this._metrics && this._metrics.updateComponentMetric(`kad-dht-${this._lan ? 'lan' : 'wan'}`, METRIC_ROUTING_TABLE_SIZE, this.size)
+    this._metrics && this._metrics.updateComponentMetric({ component: `kad-dht-${this._lan ? 'lan' : 'wan'}`, metric: METRIC_ROUTING_TABLE_SIZE, value: this.size })
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,5 +161,5 @@ export interface Addressable {
 }
 
 export interface Metrics {
-  updateComponentMetric: (component: string, metric: string, value: number) => void
+  updateComponentMetric: (options: { component: string, metric: string, value: number }) => void
 }


### PR DESCRIPTION
Latest libp2p switches to `{ system, component, metric, name }` as input