### PR TITLE
Export ./content-routing, ./kad-dht and ./message

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,12 @@
   "exports": {
     ".": {
       "import": "./dist/src/index.js"
+    },
+    "./content-routing": {
+      "import": "./dist/src/content-routing/index.js"
+    },
+    "./message": {
+      "import": "./dist/src/message/index.js"
     }
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     },
     "./message": {
       "import": "./dist/src/message/index.js"
+    },
+    "./kad-dht": {
+      "import": "./dist/src/kad-dht.js"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
When working on lower-level DHT provider I noticed that I can not directly get types and values from content-routing, kad-dht and message-related files. This PR makes them available for an external package to use.