### PR TITLE
fix: remove p-map dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
     "k-bucket": "^5.1.0",
     "multiformats": "^9.6.3",
     "p-defer": "^4.0.0",
-    "p-map": "^5.3.0",
     "p-queue": "^7.2.0",
     "private-ip": "^2.3.3",
     "protons-runtime": "^1.0.4",

--- a/src/peer-list/peer-distance-list.ts
+++ b/src/peer-list/peer-distance-list.ts
@@ -1,5 +1,4 @@
 import * as utils from '../utils.js'
-import pMap from 'p-map'
 import { compare as uint8ArrayCompare } from 'uint8arrays/compare'
 import { xor as uint8ArrayXor } from 'uint8arrays/xor'
 import type { PeerId } from '@libp2p/interfaces/peer-id'
@@ -77,7 +76,7 @@ export class PeerDistanceList {
       return true
     }
 
-    const dhtKeys = await pMap(peerIds, async (peerId) => await utils.convertPeerId(peerId))
+    const dhtKeys = await Promise.all(peerIds.map(utils.convertPeerId))
     const furthestDistance = this.peerDistances[this.peerDistances.length - 1].distance
 
     for (const dhtKey of dhtKeys) {


### PR DESCRIPTION
this module depends on node API making @libp2p/kad-dht unusable in browser.