### PR TITLE
docs: fix readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Feel free to join in. All welcome. Open an [issue](https://github.com/libp2p/js-
 
 This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 
-[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/contributing.md)
+[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ js-libp2p-kad-dht follows the [libp2p/kad-dht spec](https://github.com/libp2p/sp
 
 ## Contribute
 
-Feel free to join in. All welcome. Open an [issue](https://github.com/libp2p/js-libp2p-ipfs/issues)!
+Feel free to join in. All welcome. Open an [issue](https://github.com/libp2p/js-libp2p-kad-dht/issues)!
 
 This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 

--- a/README.md
+++ b/README.md
@@ -71,15 +71,15 @@ async function addDHT(libp2p) {
 Note that you may want to supply your own peer discovery function and datastore
 ### Peer Routing
 
-[![](https://raw.githubusercontent.com/libp2p/js-libp2p-interfaces/master/src/peer-routing/img/badge.png)](https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/interfaces/src/peer-routing)
+[![](https://raw.githubusercontent.com/libp2p/interface-peer-routing/master/img/badge.png)](https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/libp2p-interfaces/src/peer-routing)
 
 ### Content Routing
 
-[![](https://raw.githubusercontent.com/libp2p/js-libp2p-interfaces/master/src/content-routing/img/badge.png)](https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/interfaces/src/content-routing)
+[![](https://raw.githubusercontent.com/libp2p/interface-content-routing/master/img/badge.png)](https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/libp2p-interfaces/src/content-routing)
 
 ### Peer Discovery
 
-[![](https://raw.githubusercontent.com/libp2p/js-libp2p-interfaces/master/src/peer-discovery/img/badge.png)](https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/interfaces/src/peer-discovery)
+[![](https://github.com/libp2p/interface-peer-discovery/blob/master/img/badge.png?raw=true)](https://github.com/libp2p/js-libp2p-interfaces/tree/master/packages/libp2p-interfaces/src/peer-discovery)
 
 ## Spec
 


### PR DESCRIPTION
Solves issue #324 

**Issues addressed:**
1. Dead Peer Routing, Content Routing, Peer discovery badge images. 
2. Dead/incorrect `Open an issue...` link. This now points to the js-libp2p-kad-dht issues page, instead of a dead IPFS issues page. I also felt that pointing to the local issues page rather than IPFS was more reasonable (this is what other libp2p repos tend to do). 
3. Updated contributing badge to point to new URL. 

For the peer routing, etc. badges, I've linked the images to their respective deprecated and read-only repositories - this should prevent any future 404s and is what the updated libp2p-interfaces repo does. Clicking on the images will still redirect to the updated repositories. 

Please note that there's still a dead URL in the `dependency status` badge (below the title header). The entire domain is down, so I wasn't sure what to replace it with. 

That said, all other URL's/badges should now be working and updated. 