### PR TITLE
add protocols to messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "varint": "^6.0.0"
   },
   "devDependencies": {
-    "@libp2p/interface-mocks": "^4.0.3",
+    "@libp2p/interface-mocks": "^6.0.0",
     "@libp2p/peer-id-factory": "^1.0.18",
     "@libp2p/peer-store": "^3.1.4",
     "@types/lodash.random": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/components": "^3.0.1",
+    "@libp2p/components": "^3.0.0",
     "@libp2p/crypto": "^1.0.4",
     "@libp2p/interface-address-manager": "^2.0.0",
     "@libp2p/interface-connection": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -137,9 +137,9 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@libp2p/components": "^2.0.4",
+    "@libp2p/components": "^3.0.1",
     "@libp2p/crypto": "^1.0.4",
-    "@libp2p/interface-address-manager": "^1.0.3",
+    "@libp2p/interface-address-manager": "^2.0.0",
     "@libp2p/interface-connection": "^3.0.2",
     "@libp2p/interface-connection-manager": "^1.1.1",
     "@libp2p/interface-dht": "^1.0.1",

--- a/src/kad-dht.ts
+++ b/src/kad-dht.ts
@@ -187,12 +187,13 @@ export class KadDHT extends EventEmitter<PeerDiscoveryEvents> implements DHT, In
       const peerId = evt.detail
 
       Promise.resolve().then(async () => {
-        const multiaddrs = await this.components.getPeerStore().addressBook.get(peerId)
+        const multiaddrs = await this.components.getPeerStore().addressBook.get(peerId) ?? []
+        const protocols = await this.components.getPeerStore().protoBook.get(peerId) ?? []
 
         const peerData = {
           id: peerId,
           multiaddrs: multiaddrs.map(addr => addr.multiaddr),
-          protocols: []
+          protocols: protocols
         }
 
         await this.onPeerConnect(peerData)

--- a/src/message/dht.ts
+++ b/src/message/dht.ts
@@ -184,16 +184,16 @@ export namespace Message {
 
           if (obj.protocols != null) {
             for (const value of obj.protocols) {
-                writer.uint32(24);
-                writer.bytes(value);
+              writer.uint32(24)
+              writer.bytes(value)
             }
           } else {
-              throw new Error('Protocol error: required field "protocols" was not found in object');
+            throw new Error('Protocol error: required field "protocols" was not found in object')
           }
-          
+
           if (obj.connection != null) {
-            writer.uint32(32);
-            Message.ConnectionType.codec().encode(obj.connection, writer);
+            writer.uint32(32)
+            Message.ConnectionType.codec().encode(obj.connection, writer)
           }
 
           if (opts.lengthDelimited !== false) {

--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -1,6 +1,8 @@
 import { peerIdFromBytes } from '@libp2p/peer-id'
 import { multiaddr } from '@multiformats/multiaddr'
 import { Libp2pRecord } from '@libp2p/record'
+import { toString } from 'uint8arrays/to-string'
+import { fromString } from 'uint8arrays/from-string'
 import { Message as PBMessage } from './dht.js'
 import type { PeerInfo } from '@libp2p/interface-peer-info'
 import type { Uint8ArrayList } from 'uint8arraylist'
@@ -12,6 +14,7 @@ export const MESSAGE_TYPE_LOOKUP = Object.keys(MESSAGE_TYPE)
 interface PBPeer {
   id: Uint8Array
   addrs: Uint8Array[]
+  protocols: Uint8Array[]
   connection: PBMessage.ConnectionType
 }
 
@@ -91,6 +94,7 @@ function toPbPeer (peer: PeerInfo) {
   const output: PBPeer = {
     id: peer.id.toBytes(),
     addrs: (peer.multiaddrs ?? []).map((m) => m.bytes),
+    protocols: (peer.protocols ?? []).map((p) => fromString(p)),
     connection: CONNECTION_TYPE.CONNECTED
   }
 
@@ -105,6 +109,6 @@ function fromPbPeer (peer: PBMessage.Peer) {
   return {
     id: peerIdFromBytes(peer.id),
     multiaddrs: (peer.addrs ?? []).map((a) => multiaddr(a)),
-    protocols: []
+    protocols: (peer.protocols ?? []).map((p) => toString(p))
   }
 }

--- a/src/peer-routing/index.ts
+++ b/src/peer-routing/index.ts
@@ -90,7 +90,7 @@ export class PeerRouting implements Initializable {
       return {
         id: peerData.id,
         multiaddrs: peerData.addresses.map((address) => address.multiaddr),
-        protocols: []
+        protocols: peerData.protocols
       }
     }
 
@@ -168,7 +168,7 @@ export class PeerRouting implements Initializable {
           peer: {
             id: peer.id,
             multiaddrs: peer.addresses.map((address) => address.multiaddr),
-            protocols: []
+            protocols: peer.protocols
           }
         })
 
@@ -250,7 +250,7 @@ export class PeerRouting implements Initializable {
         peer: {
           id: peer,
           multiaddrs: (await (this.components.getPeerStore().addressBook.get(peer)) ?? []).map(addr => addr.multiaddr),
-          protocols: []
+          protocols: await (this.components.getPeerStore().protoBook.get(peer)) ?? []
         }
       })
     }


### PR DESCRIPTION
After calling `getClosestPeers`, I was expecting that the protobook would be updated with protocols supported by newly discovered peers, but I noticed that only the addressbook is updated.