### PR TITLE
feat: allow passing ProvidersInit in KadDHT constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export interface KadDHTInit {
   maxOutboundStreams?: number
 
   /**
-   * Initalization options for the Providers component
+   * Initialization options for the Providers component
    */
   providers?: ProvidersInit
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { KadDHT as SingleKadDHT } from './kad-dht.js'
 import { DualKadDHT } from './dual-kad-dht.js'
+import type { ProvidersInit } from './providers.js'
 import type { Selectors, Validators } from '@libp2p/interface-dht'
 import type { Registrar } from '@libp2p/interface-registrar'
 import type { AddressManager } from '@libp2p/interface-address-manager'
@@ -62,6 +63,11 @@ export interface KadDHTInit {
    * How many parallel outgoing streams to allow on the DHT protocol per-connection
    */
   maxOutboundStreams?: number
+
+  /**
+   * Initalization options for the Providers component
+   */
+  providers?: ProvidersInit
 }
 
 export interface KadDHTComponents {

--- a/src/kad-dht.ts
+++ b/src/kad-dht.ts
@@ -82,7 +82,8 @@ export class KadDHT extends EventEmitter<PeerDiscoveryEvents> implements DHT {
       pingTimeout,
       pingConcurrency,
       maxInboundStreams,
-      maxOutboundStreams
+      maxOutboundStreams,
+      providers: providersInit,
     } = init
 
     this.running = false
@@ -102,7 +103,7 @@ export class KadDHT extends EventEmitter<PeerDiscoveryEvents> implements DHT {
       protocol: this.protocol
     })
 
-    this.providers = new Providers(components)
+    this.providers = new Providers(components, providersInit ?? {})
 
     this.validators = {
       ...recordValidators,

--- a/src/kad-dht.ts
+++ b/src/kad-dht.ts
@@ -83,7 +83,7 @@ export class KadDHT extends EventEmitter<PeerDiscoveryEvents> implements DHT {
       pingConcurrency,
       maxInboundStreams,
       maxOutboundStreams,
-      providers: providersInit,
+      providers: providersInit
     } = init
 
     this.running = false

--- a/test/kad-dht.spec.ts
+++ b/test/kad-dht.spec.ts
@@ -97,7 +97,7 @@ describe('KadDHT', () => {
         kBucketSize: 5,
         providers: {
           cleanupInterval: 60,
-          provideValidity: 60 * 10,
+          provideValidity: 60 * 10
         }
       })
       

--- a/test/kad-dht.spec.ts
+++ b/test/kad-dht.spec.ts
@@ -91,6 +91,21 @@ describe('KadDHT', () => {
       expect(dht).to.have.property('getMode')
       expect(dht).to.have.property('setMode')
     })
+
+    it('forward providers init options to providers component', async () => {
+      const dht = await tdht.spawn({
+        kBucketSize: 5,
+        providers: {
+          cleanupInterval: 60,
+          provideValidity: 60 * 10,
+        }
+      })
+      
+      expect(dht.lan.providers).to.have.property('cleanupInterval', 60)
+      expect(dht.lan.providers).to.have.property('provideValidity', 60 * 10)
+      expect(dht.wan.providers).to.have.property('cleanupInterval', 60)
+      expect(dht.wan.providers).to.have.property('provideValidity', 60 * 10)
+    })
   })
 
   describe('start and stop', () => {

--- a/test/kad-dht.spec.ts
+++ b/test/kad-dht.spec.ts
@@ -100,7 +100,6 @@ describe('KadDHT', () => {
           provideValidity: 60 * 10
         }
       })
-      
       expect(dht.lan.providers).to.have.property('cleanupInterval', 60)
       expect(dht.lan.providers).to.have.property('provideValidity', 60 * 10)
       expect(dht.wan.providers).to.have.property('cleanupInterval', 60)


### PR DESCRIPTION
The `Providers` component takes a `ProvidersInit` object, but there's not actually a way to provide it with one from the `KadDHT` constructor. This means users aren't able to override the defaults for how long provider records are valid for and how frequently to clean up expired provider records.

Feel free to close this if there's a different way you'd rather do it, or if for some reason it's not allowed on purpose (though I can't imagine why), but it's such a small change I thought I'd just open it as a PR.

Thanks for your time; this would really help me out!