### PR TITLE
fix: use multihash bytes for provide messages keys

### DIFF
--- a/src/content-routing/index.ts
+++ b/src/content-routing/index.ts
@@ -64,7 +64,7 @@ export class ContentRouting {
     // Add peer as provider
     await this.providers.addProvider(key, this.components.peerId)
 
-    const msg = new Message(MESSAGE_TYPE.ADD_PROVIDER, key.bytes, 0)
+    const msg = new Message(MESSAGE_TYPE.ADD_PROVIDER, key.multihash.bytes, 0)
     msg.providerPeers = [{
       id: this.components.peerId,
       multiaddrs,

--- a/test/kad-dht.spec.ts
+++ b/test/kad-dht.spec.ts
@@ -414,7 +414,7 @@ describe('KadDHT', () => {
 
       // Expect an ADD_PROVIDER message to be sent to each peer for each value
       const fn = dhts[3].lan.network.sendMessage
-      const valuesBuffs = values.map(v => v.cid.bytes)
+      const valuesBuffs = values.map(v => v.cid.multihash.bytes)
       // @ts-expect-error fn is a spy
       const calls = fn.getCalls().map(c => c.args)
 

--- a/test/utils/create-values.ts
+++ b/test/utils/create-values.ts
@@ -1,4 +1,6 @@
 import { CID } from 'multiformats/cid'
+import * as raw from 'multiformats/codecs/raw'
+
 import { sha256 } from 'multiformats/hashes/sha2'
 import { randomBytes } from '@libp2p/crypto'
 
@@ -13,7 +15,7 @@ export async function createValues (length: number): Promise<Value[]> {
       const bytes = randomBytes(32)
       const h = await sha256.digest(bytes)
       return {
-        cid: CID.createV0(h),
+        cid: CID.createV1(raw.code, h),
         value: bytes
       }
     })


### PR DESCRIPTION
This fixes a bug where `ADD_PROVIDER` message keys were CID bytes instead of multihash bytes, and changes the CIDs generated in tests to be V1s with `raw` codec instead of V0s so that the difference is actually tested..