### PR TITLE
fix: correct `KBucketTree` types

### DIFF
--- a/src/routing-table/index.ts
+++ b/src/routing-table/index.ts
@@ -51,7 +51,7 @@ export interface KBucketTree {
   add: (peer: KBucketPeer) => void
   get: (key: Uint8Array) => Uint8Array
   count: () => number
-  toIterable: () => Iterable<KBucket>
+  toIterable: () => Iterable<KBucketPeer>
 }
 
 export interface RoutingTableInit {


### PR DESCRIPTION
As the `k-bucket` documentation [here](https://github.com/tristanls/k-bucket/blob/master/README.md#kbuckettoiterable) indicates, `toIterable` yields contact objects, **not** `KBucket` objects. Here, the contact objects are `KBucketPeer` objects.

You can check this in the code [here](https://github.com/tristanls/k-bucket/blob/3aa5b4f1dacb835752995a25409ab319d2070b9e/index.js#L413) - the delegated yield `yield * node.contacts` will yield each of the elements of the `node.contacts` array in order.