### PR TITLE
fix: update p-queue types

### DIFF
--- a/src/providers.ts
+++ b/src/providers.ts
@@ -216,6 +216,11 @@ export class Providers implements Startable {
       return [...provs.keys()].map(peerIdStr => {
         return peerIdFromString(peerIdStr)
       })
+    }, {
+      // no timeout is specified for this queue so it will not
+      // throw, but this is required to get the right return
+      // type since p-queue@7.3.4
+      throwOnTimeout: true
     })
   }
 }

--- a/test/network.spec.ts
+++ b/test/network.spec.ts
@@ -15,6 +15,7 @@ import type { PeerId } from '@libp2p/interface-peer-id'
 import type { Sink } from 'it-stream-types'
 import { Uint8ArrayList } from 'uint8arraylist'
 import map from 'it-map'
+import type { Multiaddr } from '@multiformats/multiaddr'
 
 describe('Network', () => {
   let dht: DualKadDHT
@@ -53,7 +54,7 @@ describe('Network', () => {
       const msg = new Message(MESSAGE_TYPE.PING, uint8ArrayFromString('hello'), 0)
 
       // mock it
-      dht.components.connectionManager.openConnection = async (peer: PeerId) => {
+      dht.components.connectionManager.openConnection = async (peer: PeerId | Multiaddr) => {
         // @ts-expect-error incomplete implementation
         const connection: Connection = {
           newStream: async (protocols: string | string[]) => {

--- a/test/providers.spec.ts
+++ b/test/providers.spec.ts
@@ -68,8 +68,8 @@ describe('Providers', () => {
       cacheSize: 10
     })
 
-    const hashes = await Promise.all([...new Array(100)].map((i: number) => {
-      return sha256.digest(uint8ArrayFromString(`hello ${i}`))
+    const hashes = await Promise.all([...new Array(100)].map(async (i: number) => {
+      return await sha256.digest(uint8ArrayFromString(`hello ${i}`))
     }))
 
     const cids = hashes.map((h) => CID.createV0(h))

--- a/test/routing-table.spec.ts
+++ b/test/routing-table.spec.ts
@@ -113,8 +113,8 @@ describe('Routing Table', () => {
     let fn: (() => Promise<any>) | undefined
 
     // execute queued functions immediately
+    // @ts-expect-error incomplete implementation
     table.pingQueue = {
-      // @ts-expect-error
       add: async (f: () => Promise<any>) => {
         fn = f
       },
@@ -175,8 +175,8 @@ describe('Routing Table', () => {
     let fn: (() => Promise<any>) | undefined
 
     // execute queued functions immediately
+    // @ts-expect-error incomplete implementation
     table.pingQueue = {
-      // @ts-expect-error
       add: async (f: () => Promise<any>) => {
         fn = f
       },


### PR DESCRIPTION
p-queue@7.3.4 contained a breaking change so update it's use to get the correct return types.