### PR TITLE
fix: remove timeout-abort-controller dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,6 @@
     "p-queue": "^7.3.4",
     "private-ip": "^3.0.0",
     "protons-runtime": "^5.0.0",
-    "timeout-abort-controller": "^3.0.0",
     "uint8arraylist": "^2.0.0",
     "uint8arrays": "^4.0.2",
     "varint": "^6.0.0"

--- a/src/query/manager.ts
+++ b/src/query/manager.ts
@@ -121,9 +121,7 @@ export class QueryManager implements Startable {
       if (setMaxListeners != null) {
         setMaxListeners(Infinity, signal)
       }
-    } catch (err) {
-      console.info('wat', err)
-    } // fails on node < 15.4
+    } catch {} // fails on node < 15.4
 
     const log = logger(`libp2p:kad-dht:${this.lan ? 'lan' : 'wan'}:query:` + uint8ArrayToString(key, 'base58btc'))
 

--- a/src/query/manager.ts
+++ b/src/query/manager.ts
@@ -1,4 +1,3 @@
-import { TimeoutController } from 'timeout-abort-controller'
 import { anySignal } from 'any-signal'
 import {
   ALPHA, K, DEFAULT_QUERY_TIMEOUT
@@ -39,7 +38,7 @@ export class QueryManager implements Startable {
   private readonly lan: boolean
   public disjointPaths: number
   private readonly alpha: number
-  private readonly controllers: Set<AbortController>
+  private readonly shutDownController: AbortController
   private running: boolean
   private queries: number
   private metrics?: {
@@ -52,11 +51,19 @@ export class QueryManager implements Startable {
 
     this.components = components
     this.disjointPaths = disjointPaths ?? K
-    this.controllers = new Set()
     this.running = false
     this.alpha = alpha ?? ALPHA
     this.lan = lan
     this.queries = 0
+
+    // allow us to stop queries on shut down
+    this.shutDownController = new AbortController()
+    // make sure we don't make a lot of noise in the logs
+    try {
+      if (setMaxListeners != null) {
+        setMaxListeners(Infinity, this.shutDownController.signal)
+      }
+    } catch {} // fails on node < 15.4
   }
 
   isStarted (): boolean {
@@ -83,11 +90,7 @@ export class QueryManager implements Startable {
   async stop (): Promise<void> {
     this.running = false
 
-    for (const controller of this.controllers) {
-      controller.abort()
-    }
-
-    this.controllers.clear()
+    this.shutDownController.abort()
   }
 
   async * run (key: Uint8Array, peers: PeerId[], queryFunc: QueryFunc, options: QueryOptions = {}): AsyncGenerator<QueryEvent> {
@@ -96,32 +99,21 @@ export class QueryManager implements Startable {
     }
 
     const stopQueryTimer = this.metrics?.queryTime.timer()
-    let timeoutController
 
     if (options.signal == null) {
       // don't let queries run forever
-      timeoutController = new TimeoutController(DEFAULT_QUERY_TIMEOUT)
-      options.signal = timeoutController.signal
+      options.signal = AbortSignal.timeout(DEFAULT_QUERY_TIMEOUT)
 
       // this signal will get listened to for network requests, etc
       // so make sure we don't make a lot of noise in the logs
       try {
         if (setMaxListeners != null) {
-          setMaxListeners(Infinity, timeoutController.signal)
+          setMaxListeners(Infinity, options.signal)
         }
       } catch {} // fails on node < 15.4
     }
 
-    // allow us to stop queries on shut down
-    const abortController = new AbortController()
-    this.controllers.add(abortController)
-    const signals = [abortController.signal]
-
-    if (options.signal != null) {
-      signals.push(options.signal)
-    }
-
-    const signal = anySignal(signals)
+    const signal = anySignal([this.shutDownController.signal, options.signal])
 
     // this signal will get listened to for every invocation of queryFunc
     // so make sure we don't make a lot of noise in the logs
@@ -129,7 +121,9 @@ export class QueryManager implements Startable {
       if (setMaxListeners != null) {
         setMaxListeners(Infinity, signal)
       }
-    } catch {} // fails on node < 15.4
+    } catch (err) {
+      console.info('wat', err)
+    } // fails on node < 15.4
 
     const log = logger(`libp2p:kad-dht:${this.lan ? 'lan' : 'wan'}:query:` + uint8ArrayToString(key, 'base58btc'))
 
@@ -185,12 +179,6 @@ export class QueryManager implements Startable {
       }
     } finally {
       signal.clear()
-
-      this.controllers.delete(abortController)
-
-      if (timeoutController != null) {
-        timeoutController.clear()
-      }
 
       this.queries--
       this.metrics?.runningQueries.update(this.queries)

--- a/src/routing-table/index.ts
+++ b/src/routing-table/index.ts
@@ -2,7 +2,6 @@
 import KBuck from 'k-bucket'
 import * as utils from '../utils.js'
 import Queue from 'p-queue'
-import { TimeoutController } from 'timeout-abort-controller'
 import { logger } from '@libp2p/logger'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { Startable } from '@libp2p/interfaces/startable'
@@ -222,13 +221,9 @@ export class RoutingTable implements Startable {
       try {
         await Promise.all(
           oldContacts.map(async oldContact => {
-            let timeoutController
-
             try {
-              timeoutController = new TimeoutController(this.pingTimeout)
-
               const options = {
-                signal: timeoutController.signal
+                signal: AbortSignal.timeout(this.pingTimeout)
               }
 
               this.log('pinging old contact %p', oldContact.peer)
@@ -245,11 +240,7 @@ export class RoutingTable implements Startable {
                 this.kb.remove(oldContact.id)
               }
             } finally {
-              if (timeoutController != null) {
-                timeoutController.clear()
-              }
-
-              this.metrics?.routingTableSize.update(this.size)
+               this.metrics?.routingTableSize.update(this.size)
             }
           })
         )

--- a/src/routing-table/index.ts
+++ b/src/routing-table/index.ts
@@ -240,7 +240,7 @@ export class RoutingTable implements Startable {
                 this.kb.remove(oldContact.id)
               }
             } finally {
-               this.metrics?.routingTableSize.update(this.size)
+              this.metrics?.routingTableSize.update(this.size)
             }
           })
         )


### PR DESCRIPTION
Use `AbortSignal.timeout` instead of the `timeout-abort-controller` dep.

Refs: https://github.com/libp2p/js-libp2p/issues/1681