### PR TITLE
fix: only choose query peers after initial self-query has run

### DIFF
--- a/src/content-fetching/index.ts
+++ b/src/content-fetching/index.ts
@@ -258,6 +258,6 @@ export class ContentFetching {
     }
 
     // we have peers, lets send the actual query to them
-    yield * this.queryManager.run(key, rtp, getValueQuery, options)
+    yield * this.queryManager.run(key, getValueQuery, options)
   }
 }

--- a/src/content-fetching/index.ts
+++ b/src/content-fetching/index.ts
@@ -40,11 +40,10 @@ export class ContentFetching {
   private readonly selectors: Selectors
   private readonly peerRouting: PeerRouting
   private readonly queryManager: QueryManager
-  private readonly routingTable: RoutingTable
   private readonly network: Network
 
   constructor (components: KadDHTComponents, init: ContentFetchingInit) {
-    const { validators, selectors, peerRouting, queryManager, routingTable, network, lan } = init
+    const { validators, selectors, peerRouting, queryManager, network, lan } = init
 
     this.components = components
     this.log = logger(`libp2p:kad-dht:${lan ? 'lan' : 'wan'}:content-fetching`)
@@ -52,7 +51,6 @@ export class ContentFetching {
     this.selectors = selectors
     this.peerRouting = peerRouting
     this.queryManager = queryManager
-    this.routingTable = routingTable
     this.network = network
   }
 
@@ -246,11 +244,6 @@ export class ContentFetching {
     } catch (err: any) {
       this.log('error getting local value for %b', key, err)
     }
-
-    const id = await convertBuffer(key)
-    const rtp = this.routingTable.closestPeers(id)
-
-    this.log('found %d peers in routing table', rtp.length)
 
     const self = this // eslint-disable-line @typescript-eslint/no-this-alias
 

--- a/src/content-fetching/index.ts
+++ b/src/content-fetching/index.ts
@@ -15,13 +15,12 @@ import {
   valueEvent,
   queryErrorEvent
 } from '../query/events.js'
-import { createPutRecord, convertBuffer, bufferToRecordKey } from '../utils.js'
+import { createPutRecord, bufferToRecordKey } from '../utils.js'
 import type { KadDHTComponents, Validators, Selectors, ValueEvent, QueryOptions, QueryEvent } from '../index.js'
 import type { Network } from '../network.js'
 import type { PeerRouting } from '../peer-routing/index.js'
 import type { QueryManager } from '../query/manager.js'
 import type { QueryFunc } from '../query/types.js'
-import type { RoutingTable } from '../routing-table/index.js'
 import type { AbortOptions } from '@libp2p/interfaces'
 import type { Logger } from '@libp2p/logger'
 
@@ -30,7 +29,6 @@ export interface ContentFetchingInit {
   selectors: Selectors
   peerRouting: PeerRouting
   queryManager: QueryManager
-  routingTable: RoutingTable
   network: Network
   lan: boolean
 }

--- a/src/content-routing/index.ts
+++ b/src/content-routing/index.ts
@@ -9,7 +9,6 @@ import {
   peerResponseEvent,
   providerEvent
 } from '../query/events.js'
-import { convertBuffer } from '../utils.js'
 import type { KadDHTComponents, PeerResponseEvent, ProviderEvent, QueryEvent, QueryOptions } from '../index.js'
 import type { Network } from '../network.js'
 import type { PeerRouting } from '../peer-routing/index.js'
@@ -126,7 +125,6 @@ export class ContentRouting {
   async * findProviders (key: CID, options: QueryOptions): AsyncGenerator<PeerResponseEvent | ProviderEvent | QueryEvent> {
     const toFind = this.routingTable.kBucketSize
     const target = key.multihash.bytes
-    const id = await convertBuffer(target)
     const self = this // eslint-disable-line @typescript-eslint/no-this-alias
 
     this.log('findProviders %c', key)
@@ -175,7 +173,7 @@ export class ContentRouting {
 
     const providers = new Set(provs.map(p => p.toString()))
 
-    for await (const event of this.queryManager.run(target, this.routingTable.closestPeers(id), findProvidersQuery, options)) {
+    for await (const event of this.queryManager.run(target, findProvidersQuery, options)) {
       yield event
 
       if (event.name === 'PEER_RESPONSE') {

--- a/src/kad-dht.ts
+++ b/src/kad-dht.ts
@@ -131,7 +131,8 @@ export class DefaultKadDHT extends EventEmitter<PeerDiscoveryEvents> implements 
       // Number of disjoint query paths to use - This is set to `kBucketSize/2` per the S/Kademlia paper
       disjointPaths: Math.ceil(this.kBucketSize / 2),
       lan,
-      initialQuerySelfHasRun
+      initialQuerySelfHasRun,
+      routingTable: this.routingTable
     })
 
     // DHT components
@@ -147,7 +148,6 @@ export class DefaultKadDHT extends EventEmitter<PeerDiscoveryEvents> implements 
       selectors: this.selectors,
       peerRouting: this.peerRouting,
       queryManager: this.queryManager,
-      routingTable: this.routingTable,
       network: this.network,
       lan: this.lan
     })

--- a/src/peer-routing/index.ts
+++ b/src/peer-routing/index.ts
@@ -148,34 +148,6 @@ export class PeerRouting {
       return
     }
 
-    const key = await utils.convertPeerId(id)
-    const peers = this.routingTable.closestPeers(key)
-
-    // sanity check
-    const match = peers.find((p) => p.equals(id))
-
-    if (match != null) {
-      try {
-        const peer = await this.components.peerStore.get(id)
-
-        this.log('found in peerStore')
-        yield finalPeerEvent({
-          from: this.components.peerId,
-          peer: {
-            id: peer.id,
-            multiaddrs: peer.addresses.map((address) => address.multiaddr),
-            protocols: []
-          }
-        })
-
-        return
-      } catch (err: any) {
-        if (err.code !== 'ERR_NOT_FOUND') {
-          throw err
-        }
-      }
-    }
-
     const self = this // eslint-disable-line @typescript-eslint/no-this-alias
 
     const findPeerQuery: QueryFunc = async function * ({ peer, signal }) {
@@ -197,7 +169,7 @@ export class PeerRouting {
 
     let foundPeer = false
 
-    for await (const event of this.queryManager.run(id.toBytes(), peers, findPeerQuery, options)) {
+    for await (const event of this.queryManager.run(id.toBytes(), findPeerQuery, options)) {
       if (event.name === 'FINAL_PEER') {
         foundPeer = true
       }
@@ -230,7 +202,7 @@ export class PeerRouting {
       yield * self.network.sendRequest(peer, request, { signal })
     }
 
-    for await (const event of this.queryManager.run(key, tablePeers, getCloserPeersQuery, options)) {
+    for await (const event of this.queryManager.run(key, getCloserPeersQuery, options)) {
       yield event
 
       if (event.name === 'PEER_RESPONSE') {

--- a/src/query/manager.ts
+++ b/src/query/manager.ts
@@ -9,16 +9,16 @@ import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import {
   ALPHA, K, DEFAULT_QUERY_TIMEOUT
 } from '../constants.js'
+import { convertBuffer } from '../utils.js'
 import { queryPath } from './query-path.js'
 import type { QueryFunc } from './types.js'
 import type { QueryEvent } from '../index.js'
+import type { RoutingTable } from '../routing-table/index.js'
 import type { Metric, Metrics } from '@libp2p/interface-metrics'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { AbortOptions } from '@libp2p/interfaces'
 import type { Startable } from '@libp2p/interfaces/startable'
 import type { DeferredPromise } from 'p-defer'
-import type { RoutingTable } from '../routing-table/index.js'
-import { convertBuffer } from '../utils.js'
 
 export interface CleanUpEvents {
   'cleanup': CustomEvent
@@ -57,7 +57,8 @@ export class QueryManager implements Startable {
     runningQueries: Metric
     queryTime: Metric
   }
-  private routingTable: RoutingTable
+
+  private readonly routingTable: RoutingTable
   private initialQuerySelfHasRun?: DeferredPromise<void>
 
   constructor (components: QueryManagerComponents, init: QueryManagerInit) {

--- a/src/query/manager.ts
+++ b/src/query/manager.ts
@@ -17,6 +17,8 @@ import type { PeerId } from '@libp2p/interface-peer-id'
 import type { AbortOptions } from '@libp2p/interfaces'
 import type { Startable } from '@libp2p/interfaces/startable'
 import type { DeferredPromise } from 'p-defer'
+import type { RoutingTable } from '../routing-table/index.js'
+import { convertBuffer } from '../utils.js'
 
 export interface CleanUpEvents {
   'cleanup': CustomEvent
@@ -27,6 +29,7 @@ export interface QueryManagerInit {
   disjointPaths?: number
   alpha?: number
   initialQuerySelfHasRun: DeferredPromise<void>
+  routingTable: RoutingTable
 }
 
 export interface QueryManagerComponents {
@@ -54,7 +57,7 @@ export class QueryManager implements Startable {
     runningQueries: Metric
     queryTime: Metric
   }
-
+  private routingTable: RoutingTable
   private initialQuerySelfHasRun?: DeferredPromise<void>
 
   constructor (components: QueryManagerComponents, init: QueryManagerInit) {
@@ -67,6 +70,7 @@ export class QueryManager implements Startable {
     this.lan = lan
     this.queries = 0
     this.initialQuerySelfHasRun = init.initialQuerySelfHasRun
+    this.routingTable = init.routingTable
 
     // allow us to stop queries on shut down
     this.shutDownController = new AbortController()
@@ -105,7 +109,7 @@ export class QueryManager implements Startable {
     this.shutDownController.abort()
   }
 
-  async * run (key: Uint8Array, peers: PeerId[], queryFunc: QueryFunc, options: QueryOptions = {}): AsyncGenerator<QueryEvent> {
+  async * run (key: Uint8Array, queryFunc: QueryFunc, options: QueryOptions = {}): AsyncGenerator<QueryEvent> {
     if (!this.running) {
       throw new Error('QueryManager not started')
     }
@@ -138,7 +142,6 @@ export class QueryManager implements Startable {
     const log = logger(`libp2p:kad-dht:${this.lan ? 'lan' : 'wan'}:query:` + uint8ArrayToString(key, 'base58btc'))
 
     // query a subset of peers up to `kBucketSize / 2` in length
-    const peersToQuery = peers.slice(0, Math.min(this.disjointPaths, peers.length))
     const startTime = Date.now()
     const cleanUp = new EventEmitter<CleanUpEvents>()
 
@@ -161,6 +164,10 @@ export class QueryManager implements Startable {
       log('query:start')
       this.queries++
       this.metrics?.runningQueries.update(this.queries)
+
+      const id = await convertBuffer(key)
+      const peers = this.routingTable.closestPeers(id)
+      const peersToQuery = peers.slice(0, Math.min(this.disjointPaths, peers.length))
 
       if (peers.length === 0) {
         log.error('Running query with no peers')

--- a/test/query.spec.ts
+++ b/test/query.spec.ts
@@ -5,6 +5,7 @@ import delay from 'delay'
 import all from 'it-all'
 import drain from 'it-drain'
 import pDefer from 'p-defer'
+import { type StubbedInstance, stubInterface } from 'ts-sinon'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { EventTypes, type QueryEvent } from '../src/index.js'
 import { MESSAGE_TYPE } from '../src/message/index.js'
@@ -18,9 +19,8 @@ import { convertBuffer } from '../src/utils.js'
 import { createPeerId, createPeerIds } from './utils/create-peer-id.js'
 import { sortClosestPeers } from './utils/sort-closest-peers.js'
 import type { QueryFunc } from '../src/query/types.js'
-import type { PeerId } from '@libp2p/interface-peer-id'
-import { StubbedInstance, stubInterface } from 'ts-sinon'
 import type { RoutingTable } from '../src/routing-table/index.js'
+import type { PeerId } from '@libp2p/interface-peer-id'
 
 interface TopologyEntry {
   delay?: number

--- a/test/query.spec.ts
+++ b/test/query.spec.ts
@@ -19,6 +19,8 @@ import { createPeerId, createPeerIds } from './utils/create-peer-id.js'
 import { sortClosestPeers } from './utils/sort-closest-peers.js'
 import type { QueryFunc } from '../src/query/types.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
+import { StubbedInstance, stubInterface } from 'ts-sinon'
+import type { RoutingTable } from '../src/routing-table/index.js'
 
 interface TopologyEntry {
   delay?: number
@@ -33,20 +35,22 @@ type Topology = Record<string, {
   event: QueryEvent
 }>
 
-const defaultInit = (): QueryManagerInit => {
-  const init: QueryManagerInit = {
-    initialQuerySelfHasRun: pDefer<any>()
-  }
-
-  init.initialQuerySelfHasRun.resolve()
-
-  return init
-}
-
 describe('QueryManager', () => {
   let ourPeerId: PeerId
   let peers: PeerId[]
   let key: Uint8Array
+  let routingTable: StubbedInstance<RoutingTable>
+
+  const defaultInit = (): QueryManagerInit => {
+    const init: QueryManagerInit = {
+      initialQuerySelfHasRun: pDefer<any>(),
+      routingTable
+    }
+
+    init.initialQuerySelfHasRun.resolve()
+
+    return init
+  }
 
   function createTopology (opts: Record<number, { delay?: number, error?: Error, value?: Uint8Array, closerPeers?: number[] }>): Topology {
     const topology: Record<string, { delay?: number, error?: Error, event: QueryEvent }> = {}
@@ -103,12 +107,18 @@ describe('QueryManager', () => {
   }
 
   before(async () => {
+    routingTable = stubInterface<RoutingTable>()
+
     const unsortedPeers = await createPeerIds(39)
     ourPeerId = await createPeerId()
     key = (await createPeerId()).toBytes()
 
     // sort remaining peers by XOR distance to the key, low -> high
     peers = await sortClosestPeers(unsortedPeers, await convertBuffer(key))
+  })
+
+  beforeEach(async () => {
+    routingTable.closestPeers.returns(peers)
   })
 
   it('does not run queries before start', async () => {
@@ -160,7 +170,7 @@ describe('QueryManager', () => {
       })
     }
 
-    const results = await all(manager.run(key, peers, queryFunc))
+    const results = await all(manager.run(key, queryFunc))
 
     expect(results).to.have.lengthOf(1)
     // @ts-expect-error types are wrong
@@ -209,7 +219,8 @@ describe('QueryManager', () => {
       }
     }
 
-    const results = await all(manager.run(key, [peers[7]], queryFunc))
+    routingTable.closestPeers.returns([peers[7]])
+    const results = await all(manager.run(key, queryFunc))
 
     // e.g. our starting peer plus the 5x closerPeers returned n the first iteration
     expect(results).to.have.lengthOf(6)
@@ -253,7 +264,8 @@ describe('QueryManager', () => {
       }
     }
 
-    const results = await all(manager.run(key, [peers[7]], queryFunc))
+    routingTable.closestPeers.returns([peers[7]])
+    const results = await all(manager.run(key, queryFunc))
 
     // e.g. our starting peer plus the 5x closerPeers returned n the first iteration
     expect(results).to.have.lengthOf(6)
@@ -301,7 +313,7 @@ describe('QueryManager', () => {
       controller.abort()
     }, 10)
 
-    await expect(all(manager.run(key, peers, queryFunc, { signal: controller.signal }))).to.eventually.be.rejected().with.property('code', 'ERR_QUERY_ABORTED')
+    await expect(all(manager.run(key, queryFunc, { signal: controller.signal }))).to.eventually.be.rejected().with.property('code', 'ERR_QUERY_ABORTED')
 
     expect(aborted).to.be.true()
 
@@ -348,7 +360,8 @@ describe('QueryManager', () => {
       yield res.event
     }
 
-    const result = await all(manager.run(key, [peers[2], peers[4]], queryFunc, { queryFuncTimeout: 500 }))
+    routingTable.closestPeers.returns([peers[2], peers[4]])
+    const result = await all(manager.run(key, queryFunc, { queryFuncTimeout: 500 }))
 
     // should have traversed through the three nodes to the value and the one that timed out
     expect(result).to.have.lengthOf(4)
@@ -378,7 +391,7 @@ describe('QueryManager', () => {
       }
     }
 
-    const results = await all(manager.run(key, peers, queryFunc))
+    const results = await all(manager.run(key, queryFunc))
 
     // didn't add any extra peers during the query
     expect(results).to.have.lengthOf(manager.disjointPaths)
@@ -409,7 +422,8 @@ describe('QueryManager', () => {
       yield valueEvent({ from: peer, value: uint8ArrayFromString('cool') })
     }
 
-    const results = await all(manager.run(key, [], queryFunc))
+    routingTable.closestPeers.returns([])
+    const results = await all(manager.run(key, queryFunc))
 
     expect(results).to.have.lengthOf(0)
 
@@ -441,7 +455,8 @@ describe('QueryManager', () => {
       0: { value: uint8ArrayFromString('hello world') }
     })
 
-    const results = await all(manager.run(key, [peers[9]], createQueryFunction(topology)))
+    routingTable.closestPeers.returns([peers[9]])
+    const results = await all(manager.run(key, createQueryFunction(topology)))
     const traversedPeers = results
       .map(event => {
         if (event.type !== EventTypes.PEER_RESPONSE && event.type !== EventTypes.VALUE) {
@@ -487,7 +502,8 @@ describe('QueryManager', () => {
       0: { value: uint8ArrayFromString('hello world') }
     })
 
-    const results = await all(manager.run(key, [peers[6], peers[5]], createQueryFunction(topology)))
+    routingTable.closestPeers.returns([peers[6], peers[5]])
+    const results = await all(manager.run(key, createQueryFunction(topology)))
     const traversedPeers = results
       .map(event => {
         if (event.type !== EventTypes.PEER_RESPONSE && event.type !== EventTypes.VALUE) {
@@ -524,7 +540,8 @@ describe('QueryManager', () => {
       })
     }
 
-    const results = await all(manager.run(key, [peers[3]], queryFunc))
+    routingTable.closestPeers.returns([peers[3]])
+    const results = await all(manager.run(key, queryFunc))
 
     expect(results).to.have.lengthOf(2)
     expect(results).to.have.deep.nested.property('[0].closer[0].id', peers[2])
@@ -559,7 +576,8 @@ describe('QueryManager', () => {
       9: { closerPeers: [2] }
     })
 
-    const results = await all(manager.run(key, [peers[9], peers[8], peers[7]], createQueryFunction(topology)))
+    routingTable.closestPeers.returns([peers[9], peers[8], peers[7]])
+    const results = await all(manager.run(key, createQueryFunction(topology)))
 
     // Should visit all peers
     expect(results).to.have.lengthOf(10)
@@ -611,7 +629,8 @@ describe('QueryManager', () => {
     }
 
     // shutdown will cause the query to stop early but without an error
-    await drain(manager.run(key, [peers[3]], queryFunc))
+    routingTable.closestPeers.returns([peers[3]])
+    await drain(manager.run(key, queryFunc))
 
     // Should only visit peers up to the point where we shut down
     expect(visited).to.have.lengthOf(2)
@@ -641,7 +660,8 @@ describe('QueryManager', () => {
       4: { closerPeers: [3] }
     })
 
-    const results = await all(manager.run(key, [peers[2], peers[4]], createQueryFunction(topology)))
+    routingTable.closestPeers.returns([peers[2], peers[4]])
+    const results = await all(manager.run(key, createQueryFunction(topology)))
 
     // visited all the nodes
     expect(results).to.have.lengthOf(5)
@@ -682,7 +702,8 @@ describe('QueryManager', () => {
       5: { closerPeers: [4] }
     })
 
-    const results = await all(manager.run(key, [peers[2], peers[5]], createQueryFunction(topology)))
+    routingTable.closestPeers.returns([peers[2], peers[5]])
+    const results = await all(manager.run(key, createQueryFunction(topology)))
 
     // @ts-expect-error types are wrong
     expect(results).to.deep.containSubset([{
@@ -700,7 +721,8 @@ describe('QueryManager', () => {
     const manager = new QueryManager({
       peerId: ourPeerId
     }, {
-      initialQuerySelfHasRun: pDefer<any>()
+      initialQuerySelfHasRun: pDefer<any>(),
+      routingTable
     })
     await manager.start()
 
@@ -712,7 +734,8 @@ describe('QueryManager', () => {
       })
     }
 
-    const results = await all(manager.run(key, [peers[7]], queryFunc, {
+    routingTable.closestPeers.returns([peers[7]])
+    const results = await all(manager.run(key, queryFunc, {
       // this bypasses awaiting on the initialQuerySelfHasRun deferred promise
       isSelfQuery: true
     }))
@@ -732,16 +755,19 @@ describe('QueryManager', () => {
       peerId: ourPeerId
     }, {
       initialQuerySelfHasRun,
-      alpha: 2
+      alpha: 2,
+      routingTable
     })
     await manager.start()
 
     let regularQueryTimeStarted: number = 0
     let selfQueryTimeStarted: number = Infinity
 
+    routingTable.closestPeers.returns([peers[7]])
+
     // run a regular query and the self query together
     await Promise.all([
-      all(manager.run(key, [peers[7]], async function * ({ peer }) { // eslint-disable-line require-await
+      all(manager.run(key, async function * ({ peer }) { // eslint-disable-line require-await
         regularQueryTimeStarted = Date.now()
 
         // yield query result
@@ -750,7 +776,7 @@ describe('QueryManager', () => {
           value: uint8ArrayFromString('cool')
         })
       })),
-      all(manager.run(key, [peers[7]], async function * ({ peer }) { // eslint-disable-line require-await
+      all(manager.run(key, async function * ({ peer }) { // eslint-disable-line require-await
         selfQueryTimeStarted = Date.now()
 
         // make sure we take enough time so that the `regularQuery` time diff is big enough to measure
@@ -796,7 +822,8 @@ describe('QueryManager', () => {
       6: {}
     })
 
-    const results = await all(manager.run(key, [peers[3]], createQueryFunction(topology)))
+    routingTable.closestPeers.returns([peers[3]])
+    const results = await all(manager.run(key, createQueryFunction(topology)))
 
     // should not have a value
     expect(results.find(res => res.name === 'VALUE')).to.not.be.ok()


### PR DESCRIPTION
Previously we chose peers before the self-query ran which meant there was a reasonable chance we chose 0 peers.

Instead, wait for the query to run, then choose peers to query.