### PR TITLE
fix: skip self-query if not running

### DIFF
--- a/src/query-self.ts
+++ b/src/query-self.ts
@@ -149,6 +149,10 @@ export class QuerySelf implements Startable {
     this.querySelfPromise.resolve()
     this.querySelfPromise = undefined
 
+    if (!this.started) {
+      return
+    }
+
     this.timeoutId = setTimeout(() => {
       this.querySelf()
         .catch(err => {


### PR DESCRIPTION
Make an additional check before setting the timeout to run the self-query later as sometimes the node is shut down before this happens.